### PR TITLE
Remove Blockpay

### DIFF
--- a/source/layouts/partials/_header.erb
+++ b/source/layouts/partials/_header.erb
@@ -93,7 +93,6 @@
                         <a class="dropdown-header">Where to spend</a>
                             <a class="dropdown-item" href="https://www.crypto-games.net/"><i class="fa fa-gamepad"></i> Crypto-Games</a>
                             <a class="dropdown-item" href="http://cointopay.com/M_MarketOverview.jsp"><i class="fa fa-shopping-cart"></i> Cointopay Marketplace</a>
-                            <a class="dropdown-item"  href="https://blockpay.ch/"><i class="fa fa-credit-card"></i> BlockPay</a>
                         <a class="dropdown-header">Mining Services</a>
                             <a class="dropdown-item" href="https://www.eobot.com/"><i class="fa fa-cogs"></i> Eobot</a>
                     </div>


### PR DESCRIPTION
It appears that Blockpay is Dead on Arrival. Ambitious project with near-zero development. Their website is barely functioning, their social media presence is non-existing, and for the last several months they've done nothing (considering their blog posts and roadmap). Even if a service providers wants to join in - they can't.

Gridcoin can be overwhelming as it is, I don't think we need to confuse new people more by referring to not-working/dead projects.