### PR TITLE
Updated downloads section, Remove link to Moises Gridcoin Apps, Remove Gridcoin Republic, Fixed Grammar Issue

### DIFF
--- a/source/Guides/3rdpartyapps.htm.erb
+++ b/source/Guides/3rdpartyapps.htm.erb
@@ -20,7 +20,7 @@ description: "A list of 3rd party BOINC applications - use at your own discretio
             <div class="col-sm-12">
                 <!--Start of additional software-->
                 <div class="alert alert-warning" style="text-align: center;">
-                    <p>These applications are not endorsed by BOINC nor Gridcoin, use them at your own risk.</p>
+                    <p>These applications are not endorsed by BOINC or Gridcoin, use them at your own risk.</p>
                     <p>We do not provide instructions for installing or using these applications.</p>
                 </div>
 

--- a/source/Guides/terminology.htm.erb
+++ b/source/Guides/terminology.htm.erb
@@ -507,12 +507,6 @@ description: "A guide to BOINC and Gridcoin terminology."
                         </td>
                     </tr>
                     <tr>
-                        <td>Grid Republic</td>
-                        <td>
-                            A third party Account Manager, see <a href="http://www.gridrepublic.org/">Grid Republic</a>.
-                        </td>
-                    </tr>
-                    <tr>
                         <td>Host</td>
                         <td>
                             Host is another word for your computer.

--- a/source/Guides/terminology.htm.erb
+++ b/source/Guides/terminology.htm.erb
@@ -501,12 +501,6 @@ description: "A guide to BOINC and Gridcoin terminology."
                         </td>
                     </tr>
                     <tr>
-                        <td>GR</td>
-                        <td>
-                            An abbreviation of Grid Republic.
-                        </td>
-                    </tr>
-                    <tr>
                         <td>Granted Credit</td>
                         <td>
                             Is what you get after your result has been validated by the project's validator.

--- a/source/index.htm.erb
+++ b/source/index.htm.erb
@@ -333,24 +333,24 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             <div class="col-xs-12" style="text-align:center; width: 100%;">
                 <a name="Downloads"></a>
                 <h4 style="color:white; font-weight:bold;">
-                    Gridcoin Downloads
+                    Download the Latest Gridcoin Updates
                 </h4>
             </div>
         </div>
         <div class="row" style="text-align: center;">
             <!--GRC Research Downloads-->
             <div class="col-xs-12 col-sm-4">
-                <h4 style="color:white;">Windows</h4>
+                <h4 style="color:white;">Gridcoin Research Wallet (Windows)</h4>
                     <a class="btn btn-round" style="background-color:#420479;margin:5px;font-weight:bold;" href="https://download.gridcoin.us/download/downloadstake/GridcoinResearch.msi">
-                        Gridcoin Research Wallet
+                        Download
                     </a>
-                    <h4 style="color:white;">MacOS</h4>
+                    <h4 style="color:white;">Gridcoin Research Wallet (MacOS DMG)</h4>
                     <a class="btn btn-round" style="background-color:#420479;margin:5px;font-weight:bold;" href="https://github.com/Git-Jiro/homebrew-jiro/releases">
-                        DMG packages
+                        Download
                     </a>
             </div>
             <div class="col-xs-12 col-sm-4">
-                <h4 style="color:white;">Linux</h4>
+                <h4 style="color:white;">Gridcoin Research Wallet (Linux)</h4>
                     <a class="btn btn-round" style="background-color:#420479;margin:5px;font-weight:bold;" href="https://software.opensuse.org/package/gridcoinresearch">.rpm <span class="hidden-xs hidden-sm">(opensuse/fedora)</span> package</a><br/>
                     <a class="btn btn-round" style="background-color:#420479;margin:5px;font-weight:bold;" href="https://code.launchpad.net/~gridcoin/+archive/ubuntu/gridcoin-stable">.deb <span class="hidden-xs hidden-sm">(debian/ubuntu)</span> package</a><br/>
                     <a class="btn btn-round" style="background-color:#420479;margin:5px;font-weight:bold;" href="https://aur.archlinux.org/packages/gridcoinresearch-qt">Archlinux AUR package</a>

--- a/source/layouts/partials/_header.erb
+++ b/source/layouts/partials/_header.erb
@@ -48,7 +48,6 @@
                         <a class="dropdown-header">Tools</a>
                             <a class="dropdown-item" href="/Guides/3rdpartyapps.htm"><i class="fa fa-wrench"></i> 3rd Party BOINC Apps</a>
                             <a class="dropdown-item" href="https://signature.statseb.fr/"><i class="fa fa-wrench"></i> Forum Signatures</a>
-                            <a class="dropdown-item" href="https://gridcoinapp.xyz/"><i class="fa fa-wrench"></i> Moises' Gridcoin Apps</a>
                     </div>
                 </div>
 


### PR DESCRIPTION
Brief descriptions, more detailed descriptions are in the commits.

1. Updated the downloads section so that it's a little easier to understand
2. Removed link to Moises Gridcoin Apps in wiki
3. Removed the table row containing "Gridcoin Republic" in the GRC Wiki
4. Grammar: replaced "nor" with "or" on the 3rd Party Apps page.