### PR TITLE
Fixed Slack Links

### DIFF
--- a/source/contact.htm.erb
+++ b/source/contact.htm.erb
@@ -20,7 +20,7 @@ description: "How to get in contact with the Gridcoin developers and community."
                         <a href="https://t.me/gridcoin" style="color:#7d00f4;">Gridcoin's Telegram channel</a>
                     </li>
                     <li>
-                        <a href="https://grcinvite.herokuapp.com/" style="color:#7d00f4;">Gridcoin's Slack channel</a>
+                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/" style="color:#7d00f4;">Gridcoin's Slack channel</a>
                     </li>
                     <li>
                         <a href="https://discord.me/gridcoin" style="color:#7d00f4;">Gridcoin's Discord channel</a>

--- a/source/layouts/partials/_footer.erb
+++ b/source/layouts/partials/_footer.erb
@@ -27,7 +27,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://teamgridcoin.signup.team/">
+                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/">
                             <i class="fa fa-slack"></i> Slack
                         </a>
                     </li>

--- a/source/layouts/partials/_header.erb
+++ b/source/layouts/partials/_header.erb
@@ -29,7 +29,7 @@
                         <a class="dropdown-header">Chat</a>
                             <a class="dropdown-item" href="https://t.me/gridcoin"><i class="fa fa-telegram"></i> Gridcoin (Telegram)</a>
                             <a class="dropdown-item" href="https://t.me/BOINC_Telegram"><i class="fa fa-telegram"></i> BOINC (Telegram)</a>
-                            <a class="dropdown-item" href="https://grcinvite.herokuapp.com/"><i class="fa fa-slack"></i> Slack</a>
+                            <a class="dropdown-item" href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/"><i class="fa fa-slack"></i> Slack</a>
                             <a class="dropdown-item" href="https://chat.gridcoin.io/"><i class="fa fa-rocket"></i> Rocket</a>                            
                             <a class="dropdown-item" href="https://discord.me/gridcoin"><i class="fa fa-volume-control-phone"></i>  Discord</a>
                     </div>


### PR DESCRIPTION
Slack links didn't match between header and footer. Set both to the same link, which is a non-expiring Slack invite.