### PR TITLE
Underline the snapshot download link

### DIFF
--- a/source/layouts/partials/_acquire.erb
+++ b/source/layouts/partials/_acquire.erb
@@ -25,7 +25,7 @@
                             </ul>
                         </li>
                         <li style="padding-top: 10px;">
-                        If you're having issues with 'Download Blocks', you can manually download the latest snapshot <a href="https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip">here</a>.
+                        If you're having issues with 'Download Blocks', you can manually download the latest snapshot <a href="https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip" style="text-decoration: underline;">here</a>.
                             <ul>
                                 <li>
                                 Note: The snapshot will not fully sync your client, but will rather bring you up to 80-90% sync. Allow your client to manually sync after the snapshot has been implemented.


### PR DESCRIPTION
I think without the decoration it is hard to see that the here is a link.