### PR TITLE
Temporarily removing Bitshares references

### DIFF
--- a/source/Guides/investor-gridcoin-setup.htm.erb
+++ b/source/Guides/investor-gridcoin-setup.htm.erb
@@ -126,9 +126,9 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
     <div class="container" style="overflow:hidden;">
 
         <div class='row' style="margin-top:10px;">
+            <!--
             <div class='col-xs-12 col-sm-12' style="">
                 <h4>
-                    Alternatively to running the official Gridcoin client
                 </h4>
                 <p>If you're not interested in earning POS rewards, you can use several third party Gridcoin wallets to hold your GRC off centralized exchanges.</p>
                 <h5>
@@ -139,9 +139,10 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                 <a class="btn btn-simple btn-default" href="https://bit.btsabc.org">BTSABC</a>
                 <a class="btn btn-simple btn-default" href="https://bitshares.org/">Bitshares-Light</a>
             </div>
+          -->
             <div class="col-xs-12 col-sm-12 col-md-12" style="padding-top: 15px;">
                 <h5>
-                    Multiwallets
+                    Third party multi-wallets for Gridcoin
                 </h5>
                 <a class="btn btn-simple btn-default" href="https://holytransaction.com/">HolyTransaction</a>
                 <a class="btn btn-simple btn-default" href="https://coinomi.com/">Coinomi</a>

--- a/source/Guides/pool-gridcoin-install.htm.erb
+++ b/source/Guides/pool-gridcoin-install.htm.erb
@@ -190,6 +190,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
     <div class="container" style="overflow:hidden;">
 
         <div class='row' style="margin-top:10px;">
+          <!--
             <div class='col-xs-12 col-sm-12' style="">
                 <h4>
                     Alternatively to running the official Gridcoin client
@@ -203,9 +204,10 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
                 <a class="btn btn-simple btn-default" href="https://bitshares.org/">Bitshares-Light</a>
                 <a class="btn btn-simple btn-default" href="https://bitshares.org/">Light client</a>
             </div>
+          -->
             <div class="col-xs-12 col-sm-12 col-md-12" style="padding-top: 15px;">
                 <h5>
-                    Multiwallets
+                  Third party multi-wallets for Gridcoin
                 </h5>
                 <a class="btn btn-simple btn-default" href="https://holytransaction.com/">HolyTransaction</a>
                 <a class="btn btn-simple btn-default" href="https://coinomi.com/">Coinomi</a>

--- a/source/layouts/partials/_acquire.erb
+++ b/source/layouts/partials/_acquire.erb
@@ -17,15 +17,7 @@
                             Prior to being able to stake or transfer Gridcoin to/from the Gridcoin client you need to fully sync the Gridcoin client to the latest block on the blockchain (green tick under connections indicates a fully synced wallet)
                         </li>
                         <li style="padding-top: 10px;">
-                        You can download a snapshot of the blockchain from within the client by clicking 'Rebuild block chain | Download Blocks'.
-                            <ul>
-                                <li>
-                                    Note: The 'Download Blocks' feature requires the Gridcoin client to be running as administrator in windows; without admin permissions these features will throw an error.
-                                </li>
-                            </ul>
-                        </li>
-                        <li style="padding-top: 10px;">
-                        If you're having issues with 'Download Blocks', you can manually download the latest snapshot <a href="https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip">here</a>.
+                        If you don't want to sync from 0, then you can download a snapshot of the blockchain <a href="https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip">here</a>.
                             <ul>
                                 <li>
                                 Note: The snapshot will not fully sync your client, but will rather bring you up to 80-90% sync. Allow your client to manually sync after the snapshot has been implemented.
@@ -42,7 +34,7 @@
                                     Investigate whether or not your ISP is blocking P2P traffic.
                                 </li>
                                 <li>
-                                    Verify you're running the latest version of the Gridcoin client, as there are frequent updates. Notices of updates are posted regularly on <a href="https://www.reddit.com/r/gridcoin">Reddit</a>/<a href="https://twitter.com/GridcoinNetwork">Twitter</a>/<a href="https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin">IRC</a>.
+                                    Verify you're running the latest version of the Gridcoin client, as there are frequent updates. Notices of updates are posted regularly on the <a href="../blog.htm">gridcoin blog</a> & <a href="https://twitter.com/GridcoinNetwork">Twitter</a>.
                                 </li>
                             </ul>
                         </li>

--- a/source/layouts/partials/_acquire_details.erb
+++ b/source/layouts/partials/_acquire_details.erb
@@ -4,8 +4,8 @@
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
                 <h3>How to buy Gridcoin?</h3>
                 <p>On most centralized exchanges you need to first <a href="https://www.bitcoin.com/buy-bitcoin">buy Bitcoin</a> in order to buy Gridcoin, except from on <a href="https://flyp.me">Flyp.me</a> where you can exchange several cryptocurrencies for gridcoin.</p>
-                <p>On the Bitshares based decentralized exchanges you can trade any bitshares based asset for OPEN.GRC (Gridcoin via Openledger exchange), including several fiat cryptocurrencies. You can find the most liquid trading pairs by viewing <a href="http://cryptofresh.com/a/OPEN.GRC">Cryptofresh</a> or the <a href="http://cryptofresh.com/a/OPEN.GRC">Bitshares-Explorer</a> websites.</p>
-                <p>An advantage of decentralized exchanges over centralized exchanges is that you are your own bank, the risk of the exchange being hacked and your funds stolen is far less likely than with centralized exchanges.</p>
+                <!--<p>On the Bitshares based decentralized exchanges you can trade any bitshares based asset for OPEN.GRC (Gridcoin via Openledger exchange), including several fiat cryptocurrencies. You can find the most liquid trading pairs by viewing <a href="http://cryptofresh.com/a/OPEN.GRC">Cryptofresh</a> or the <a href="http://cryptofresh.com/a/OPEN.GRC">Bitshares-Explorer</a> websites.</p>
+                <p>An advantage of decentralized exchanges over centralized exchanges is that you are your own bank, the risk of the exchange being hacked and your funds stolen is far less likely than with centralized exchanges.</p>-->
             </div>
         </div>
 
@@ -20,6 +20,7 @@
                                         <img src="../assets/img/Exchanges/bisq.png" alt="bisq" />
                                     </a>
                                 </li>
+                                <!--
                                 <li>
                                     <a href="https://door.one/">
                                         <img src="../assets/img/Exchanges/doorone.png" alt="DoorOne" />
@@ -45,6 +46,7 @@
                                         <img src="../assets/img/Exchanges/RUDEX.png" alt="RUDEX" />
                                     </a>
                                 </li>
+                              -->
                             </ul>
                         </li>
                     </ul>

--- a/source/layouts/partials/_footer.erb
+++ b/source/layouts/partials/_footer.erb
@@ -109,12 +109,12 @@
                 <ul style="list-style-type: none; padding-left: 0;">
                     <li>
                         <a href="https://t.me/gridcoin">
-                            <span style="font-weight:bold;">#</span> Gridcoin
+                            <i class="fa fa-telegram"></i>  Gridcoin
                         </a>
                     </li>
                     <li>
                         <a href="https://t.me/BOINC_Telegram">
-                            <span style="font-weight:bold;">#</span> BOINC
+                            <i class="fa fa-telegram"></i>  BOINC
                         </a>
                     </li>
                 </ul>
@@ -188,6 +188,7 @@
                                 <i class="fa fa-exchange"></i> bisq
                             </a>
                         </li>
+                        <!--
                         <li>
                             <a href="https://bit.btsabc.org/#/market/OPEN.GRC_OPEN.BTC">
                                 <i class="fa fa-exchange"></i> BTSABC
@@ -213,6 +214,7 @@
                                 <i class="fa fa-exchange"></i> RUDEX
                             </a>
                         </li>
+                      -->
                     </ul>
                 <h6 style="font-weight: bold; margin-bottom: 10px; margin-top: 10px;">Spend your Gridcoin</h6>
                 <ul style="list-style-type: none; padding-left: 0;">
@@ -259,11 +261,13 @@
                             </a>
                         </li>
                     <li role="presentation"><h6 style="font-weight: bold; margin-bottom: 10px; margin-top: 10px;">3rd party wallets</h6></li>
+                        <!--
                         <li>
                             <a href="https://play.google.com/store/apps/details?id=com.bitshares.bitshareswallet">
                                 <i class="fa fa-id-card-o"></i> BitUniverse
                             </a>
                         </li>
+                      -->
                         <li>
                             <a href="https://coinomi.com/">
                                 <i class="fa fa-id-card-o"></i> Coinomi
@@ -305,7 +309,7 @@
                         <a href="https://grcexplorer.neuralminer.io">
                             <i class="fa fa-bar-chart"></i> NeuralMiner.io
                         </a>
-                    </li>                                        
+                    </li>
                     <li role="presentation"><h6 style="font-weight: bold; margin-bottom: 10px; margin-top: 10px;">Team Stats</h6></li>
                     <li>
                         <a href="https://boincstats.com/en/stats/-1/team/detail/118094994/projectList">

--- a/source/layouts/partials/_header.erb
+++ b/source/layouts/partials/_header.erb
@@ -30,7 +30,7 @@
                             <a class="dropdown-item" href="https://t.me/gridcoin"><i class="fa fa-telegram"></i> Gridcoin (Telegram)</a>
                             <a class="dropdown-item" href="https://t.me/BOINC_Telegram"><i class="fa fa-telegram"></i> BOINC (Telegram)</a>
                             <a class="dropdown-item" href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/"><i class="fa fa-slack"></i> Slack</a>
-                            <a class="dropdown-item" href="https://chat.gridcoin.io/"><i class="fa fa-rocket"></i> Rocket</a>                            
+                            <a class="dropdown-item" href="https://chat.gridcoin.io/"><i class="fa fa-rocket"></i> Rocket</a>
                             <a class="dropdown-item" href="https://discord.me/gridcoin"><i class="fa fa-volume-control-phone"></i>  Discord</a>
                     </div>
                 </div>
@@ -78,12 +78,14 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-header">Decentralized Exchanges</a>
+                          <!--
                             <a class="dropdown-item" href="https://bitshares.openledger.info/#/market/OPEN.GRC_OPEN.BTC"><i class="fa fa-exchange"></i> OpenLedger</a>
                             <a class="dropdown-item" href="https://bit.btsabc.org/#/market/OPEN.GRC_OPEN.BTC"><i class="fa fa-exchange"></i> BTSABC</a>
                             <a class="dropdown-item" href="https://bitshares.org/"><i class="fa fa-exchange"></i> Bitshares-Light</a>
-                            <a class="dropdown-item" href="https://bisq.network/"><i class="fa fa-exchange"></i> bisq</a>
                             <a class="dropdown-item" href="https://door.one/"><i class="fa fa-exchange"></i> Door.One</a>
                             <a class="dropdown-item" href="https://staging.rudex.org/#/market/OPEN.GRC_OPEN.BTC"><i class="fa fa-exchange"></i> RUDEX</a>
+                          -->
+                            <a class="dropdown-item" href="https://bisq.network/"><i class="fa fa-exchange"></i> bisq</a>
                         <a class="dropdown-header">Centralized Exchanges</a>
                             <a class="dropdown-item" href="https://flyp.me/"><i class="fa fa-exchange"></i> Flyp.Me</a>
                             <a class="dropdown-item" href="https://poloniex.com/exchange/btc_grc"><i class="fa fa-exchange"></i> Poloniex</a>
@@ -98,7 +100,7 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-header">3rd party wallets</a>
-                            <a class="dropdown-item" href="https://play.google.com/store/apps/details?id=com.bitshares.bitshareswallet"><i class="fa fa-id-card-o"></i> BitUniverse</a>
+                            <!--<a class="dropdown-item" href="https://play.google.com/store/apps/details?id=com.bitshares.bitshareswallet"><i class="fa fa-id-card-o"></i> BitUniverse</a>-->
                             <a class="dropdown-item" href="https://coinomi.com/"><i class="fa fa-id-card-o"></i> Coinomi</a>
                             <a class="dropdown-item" href="https://holytransaction.com/"><i class="fa fa-id-card-o"></i> HolyTransaction</a>
                             <a class="dropdown-item" href="https://www.magicw.net/"><i class="fa fa-id-card-o"></i> MagicWallet</a>


### PR DESCRIPTION
OpenLedger has failed multiple times to communicate why their Gridcoin ([open.grc](http://open-explorer.io/#/assets/open.grc)) gateway has remained offline for several months longer than necessary & they have recently [lost control of their domains to a hacker](https://steemit.com/bitshares/@mtopenledger/openledger-dex-discloses-eos-and-eosdac-mainnet-token-swap-details) :face_with_head_bandage: 