### PR TITLE
Update YT URL.

### DIFF
--- a/source/layouts/partials/_footer.erb
+++ b/source/layouts/partials/_footer.erb
@@ -76,7 +76,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.youtube.com/GridcoinHangouts">
+                        <a href="https://www.youtube.com/channel/UC0Z3uczcC2okYRrLLCZFrMQ">
                             <i class="fa fa-youtube"></i> YouTube
                         </a>
                     </li>


### PR DESCRIPTION
Temp change until new permanent custom URL kicks in. Old custom URL is no longer valid.