### PR TITLE
Change Gridcoin Discord link to invite

### DIFF
--- a/source/contact.htm.erb
+++ b/source/contact.htm.erb
@@ -22,7 +22,7 @@ description: "How to get in contact with the Gridcoin developers and community."
                         <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/" >Gridcoin's Slack channel</a>
                     </li>
                     <li>
-                        <a href="https://discord.me/gridcoin" >Gridcoin's Discord channel</a>
+                        <a href="https://discord.gg/jf9XX4a" >Gridcoin's Discord channel</a>
                     </li>
                     <li>
                         <a href="https://www.reddit.com/r/gridcoin" >/r/gridcoin subreddit</a>


### PR DESCRIPTION
This should fix #167 , need someone to check that I didn't miss some other mention of Discord on the site