### PR TITLE
Issue#79 - Dynamic version number

### DIFF
--- a/_includes/_wallet_install.htm
+++ b/_includes/_wallet_install.htm
@@ -11,7 +11,7 @@
                 </h5>
                 <ul>
                     <li>
-                        <a class="btn btn-round grcbtn" href="https://download.gridcoin.us/download/downloadstake/GridcoinResearch.msi">Download Windows Client</a>
+                        <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/latest">Download Windows Client</a>
                     </li>
                 </ul>
             </div>

--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -14,5 +14,6 @@
 	<script src="/assets/js/plugins/bootstrap-switch.js"></script>
 	<!-- Control Center for Now Ui Kit: parallax effects, scripts for the example pages etc -->
 	<script src="/assets/js/now-ui-kit.js" type="text/javascript"></script>
+	<script src="/assets/js/fetch-release.js" type="text/javascript"></script>
   </body>
 </html>

--- a/assets/js/fetch-release.js
+++ b/assets/js/fetch-release.js
@@ -1,0 +1,15 @@
+function getLatestRelease() {
+    $.ajax({
+        type: 'GET',
+        url:'https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest',
+        crossDomain: true,
+        dataType: 'json',
+        success: function(data) { 
+            $('#wallet-version').text('Current Wallet Version: ' + data['name']); 
+        }
+    });
+}
+
+ $(document).ready(function() {
+   getLatestRelease();
+}); 

--- a/index.htm
+++ b/index.htm
@@ -342,8 +342,7 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
                 <h4 class="text-bold">
                     Download the latest Gridcoin Research client
                 </h4>
-                <p>
-                	Current Wallet Version: 4.0.4.0 (Leisure)
+                <p id="wallet-version">
                 </p>
             </div>
         </div>

--- a/index.htm
+++ b/index.htm
@@ -349,33 +349,21 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
         <div class="row">
             <!--GRC Research Downloads-->
             <div class="col-xs-12 col-sm-6">
-              <h4>Windows 64-bit</h4>
-              <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/download/4.0.4.0/gridcoin-4.0.4-win64-setup.exe">
-                  Download 64-bit Installer
+              <h4>Windows & Linux</h4>
+              <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/latest">
+                  Download via GitHub
               </a><br />
-              <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/download/4.0.4.0/gridcoin-4.0.4-win64-setup.exe.sha256">
-                  64-bit SHA256 Checksum
-              </a>
-            </div>
-            <div class="col-xs-12 col-sm-6">
-              <h4>Windows 32-bit</h4>
-              <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/download/4.0.4.0/gridcoin-4.0.4-win32-setup.exe">
-                  Download 32-bit Installer
-              </a><br />
-              <a class="btn btn-round grcbtn" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/download/4.0.4.0/gridcoin-4.0.4-win32-setup.exe.sha256">
-                  32-bit SHA256 Checksum
-              </a>
             </div>
             <div class="col-xs-12 col-sm-6">
               <h4>MacOS</h4>
               <a class="btn btn-round grcbtn" href="https://github.com/Git-Jiro/homebrew-jiro/releases">
-                  Download DMG
+                  Download via GitHub
               </a>
             </div>
             <div class="col-xs-12 col-sm-6">
-              <h4>Linux</h4>
-              <a class="btn btn-round grcbtn" href="https://software.opensuse.org/package/gridcoinresearch">.rpm <span class="hidden-xs hidden-sm">(opensuse/fedora)</span> package</a><br/>
-              <a class="btn btn-round grcbtn" href="https://code.launchpad.net/~gridcoin/+archive/ubuntu/gridcoin-stable">.deb <span class="hidden-xs hidden-sm">(debian/ubuntu)</span> package</a><br/>
+              <h4>Alternative Linux sources</h4>
+              <a class="btn btn-round grcbtn" href="https://software.opensuse.org/package/gridcoinresearch">.rpm package</a><br/>
+              <a class="btn btn-round grcbtn" href="https://code.launchpad.net/~gridcoin/+archive/ubuntu/gridcoin-stable">.deb package</a><br/>
               <a class="btn btn-round grcbtn" href="https://aur.archlinux.org/packages/gridcoinresearch-qt">Archlinux AUR package</a>
             </div>
             <!--/GRC Research Downloads-->

--- a/index.htm
+++ b/index.htm
@@ -363,7 +363,7 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             <div class="col-xs-12 col-sm-6">
               <h4>Alternative Linux sources</h4>
               <a class="btn btn-round grcbtn" href="https://software.opensuse.org/package/gridcoinresearch">.rpm package</a><br/>
-              <a class="btn btn-round grcbtn" href="https://code.launchpad.net/~gridcoin/+archive/ubuntu/gridcoin-stable">.deb package</a><br/>
+              <a class="btn btn-round grcbtn" href="https://code.launchpad.net/~gridcoin/+archive/ubuntu/gridcoin-stable">Ubuntu package</a><br/>
               <a class="btn btn-round grcbtn" href="https://aur.archlinux.org/packages/gridcoinresearch-qt">Archlinux AUR package</a>
             </div>
             <!--/GRC Research Downloads-->

--- a/index.htm
+++ b/index.htm
@@ -340,7 +340,7 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             <div class="col-xs-12">
                 <a name="Downloads"></a>
                 <h4 class="text-bold">
-                    Download the latest Gridcoin Research client
+                    Latest Gridcoin Research Client
                 </h4>
                 <p id="wallet-version">
                 </p>

--- a/source/assets/js/fetch-release.js
+++ b/source/assets/js/fetch-release.js
@@ -1,0 +1,15 @@
+function getLatestRelease() {
+    $.ajax({
+        type: 'GET',
+        url:'https://api.github.com/repos/gridcoin-community/Gridcoin-Research/releases/latest',
+        crossDomain: true,
+        dataType: 'json',
+        success: function(data) { 
+            $('#wallet-version').text('Current Wallet Version: ' + data['name']); 
+        }
+    });
+}
+
+$(document).ready(function() {
+   getLatestRelease();
+});


### PR DESCRIPTION
Clean PR for the dynamic version number.

Right now it's purely the version number that updates. If #174 is merged I could expand this to automatically update download links based on assets available on Github.

Depends if we are moving 100% to hosting all download assets on github.
Would require labelling each asset to make it easier to filter them.