### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+sudo: false
+cache: bundler
+
+rvm:
+  - 2.5
+
+install: bundle install 
+
+script: bundle exec jekyll build

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,14 @@ license_url: https://opensource.org/licenses/MIT
 #
 # Build settings
 #
-exclude: [README.md,LICENSE,"Reference Libraries","Old Data",Gemfile,Gemfile.lock]
+exclude:
+  - .travis.yml
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - Old Data
+  - README.md
+  - Reference Libraries
 
 destination: build
 


### PR DESCRIPTION
Provides support for basic Jekyll build validation in Travis. I think @grctest or @denravonska will need to enable the repo. If we rename the repository, it will need a sync from Travis afterward.