### PR TITLE
Add sitemap auto generation.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ license_url: https://opensource.org/licenses/MIT
 #
 # Build settings
 #
+repository: gridcoin-community/Gridcoin-Site
 exclude:
   - .travis.yml
   - Gemfile
@@ -23,12 +24,16 @@ exclude:
   - Old Data
   - README.md
   - Reference Libraries
+  - CNAME
 
 destination: build
 
 sass:
   sass_dir: assets/sass
 
+gems:
+  - jekyll-sitemap
+  
 #
 # Front Matter Defaults
 #


### PR DESCRIPTION
This enable sitemap auto generation on build.

The repository tag enables local github meta data which will get rid of 'no repo' error when building locally.
We use 'gems' cause github uses version 3.1.6
also excluded CNAME on the build.