### PR TITLE
Fix Universe@home Link

### DIFF
--- a/_data/whitelist.yml
+++ b/_data/whitelist.yml
@@ -64,7 +64,7 @@ projects:
   team: "https://gene.disi.unitn.it/test/team_display.php?teamid=61"
   stats: "https://www.gridcoinstats.eu/project/tn-grid"
 - name: "Universe@home"
-  link: "https://www.universeathome.pl/universe/"
+  link: "https://universeathome.pl/universe/"
   goal: "Physics and Astronomy"
   sponsor: "University of Warsaw"
   cpu: "yes"


### PR DESCRIPTION
Universe@home's https certificate isn't valid for the www subdomain, making www.universeathome.pl/universe show a certificate error when shown. https://universeathome.pl/universe/ without the www subdomain doesn't show the error