### PR TITLE
Update bootstrap classes from V3 to v4 - Fixes IE11 issues

### DIFF
--- a/Dev/rpc-reference.htm
+++ b/Dev/rpc-reference.htm
@@ -6,7 +6,7 @@ description: ""
 <section class="grc-ref grc-bgcolor grclink" data-background-color="black">
     <div class="container">
         <div class='row'>
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                 <h3 class="text-bold">Gridcoin RPC Reference</h3>
                 <p>This page provides the commands available within the Gridcoin-Research client.</p>
                 <ul>
@@ -24,12 +24,12 @@ description: ""
   <section class="grc-bgcolor" data-background-color="black">
       <div class="container">
         <div class="row" style="border-bottom: 1px dashed grey;">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
               <a name="wallet_commands"></a>
               <h4><b>Wallet commands</b></h4>
             </div>
             {% for command in site.data.wallet_commands.commands %}
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                     <h5>
                       <b>{{ command.command }}</b>
                       {% if command.parameters != "" %}
@@ -49,12 +49,12 @@ description: ""
         </div>
 
         <div class="row" style="padding-top:50px;border-bottom: 1px dashed grey;">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <a name="mining_commands"></a>
             <h4><b>Mining commands</b></h4>
           </div>
             {% for command in site.data.mining_commands.commands %}
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                     <h5>
                       <b>{{ command.command }}</b>
                       {% if command.parameters != "" %}
@@ -74,12 +74,12 @@ description: ""
         </div>
 
         <div class="row" style="padding-top:50px;">
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+          <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <a name="network_commands"></a>
             <h4><b>Network commands</b></h4>
           </div>
             {% for command in site.data.network_commands.commands %}
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                     <h5>
                       <b>{{ command.command }}</b>
                       {% if command.parameters != "" %}

--- a/Guides/acquire-grc.htm
+++ b/Guides/acquire-grc.htm
@@ -5,7 +5,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -14,7 +14,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -23,7 +23,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -32,7 +32,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">
@@ -51,7 +51,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -60,7 +60,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -69,7 +69,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -78,7 +78,7 @@ description: "Step 3 of the solo crunching guide; Informing the user how to sync
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">

--- a/Guides/boinc-install.htm
+++ b/Guides/boinc-install.htm
@@ -5,7 +5,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -14,7 +14,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -23,7 +23,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -32,7 +32,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">
@@ -52,7 +52,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -61,7 +61,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -70,7 +70,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -79,7 +79,7 @@ description: "Step 1 of the solo crunching guide; Introducing the user to BOINC,
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">

--- a/Guides/earn-grc.htm
+++ b/Guides/earn-grc.htm
@@ -5,7 +5,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5 >Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -14,7 +14,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -23,7 +23,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -32,7 +32,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">
@@ -49,7 +49,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
         <div class="container">
             <!--Step 1-->
             <div class='row'>
-                <div class='col-xs-12 col-sm-12 text-center'>
+                <div class='col-12 col-sm-12 text-center'>
                     <h4 class="text-bold text-center">
                         Steps to Earn GRC via DPOR
                     </h4>
@@ -58,7 +58,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
             <!--/Step 1-->
             <!--Contibute content-->
             <div class="row">
-                <div class="col-xs-12 col-sm-12">
+                <div class="col-12 col-sm-12">
                     <ul>
                         <li>
                             <h5 class="text-center">1) Check Your Projects</h5>
@@ -141,7 +141,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
 <section class="guide-menu-bot grc-bgcolor"  data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -150,7 +150,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -159,7 +159,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -168,7 +168,7 @@ description: "Step 4 of the solo crunching guide; Instructing users how they can
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">

--- a/Guides/gridcoin-install.htm
+++ b/Guides/gridcoin-install.htm
@@ -5,7 +5,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -14,7 +14,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -23,7 +23,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -32,7 +32,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">
@@ -48,7 +48,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
 <section class="grc-inst-sec-2 grc-bgcolor grclink" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-8 col-md-8">
+            <div class="col-12 col-sm-8 col-md-8">
                 <h4 class="text-bold">Gridcoin Introduction</h4>
                 <p>To earn Gridcoin in solo staking mode you need to run the Gridcoin client and continuously stake.</p>
                 <p>If you have not yet installed the BOINC client, you should read the <a href="/Guides/boinc-install.htm">BOINC installation guide</a> to setup BOINC. The BOINC client has to be installed alongside the Gridcoin client in order to verify BOINC account ownership and to access local BOINC statistics.</p>
@@ -66,7 +66,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
 <section class="grc-bgcolor" data-background-color="black">
     <div class="container">
             <div class="row">
-                <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center'>
+                <div class='col-12 col-sm-12 col-md-12 col-lg-12 text-center'>
                     <h4 class="text-bold">
                         Optional post-install Gridcoin configuration
                     </h4>
@@ -75,7 +75,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
 
             <!--prereqs-->
             <div class="row">
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                     <p>
                         If you installed the BOINC client anywhere other than the default installation location, you'll need to specify where you installed BOINC in the gridcoinresearch.conf file.
                     </p>
@@ -125,7 +125,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/boinc-install.htm">
@@ -134,7 +134,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/gridcoin-install.htm">
@@ -143,7 +143,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/acquire-grc.htm">
@@ -152,7 +152,7 @@ description: "Step 2 of the solo crunching guide; Instructing the user how to se
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-3 col-lg-3">
+            <div class="col-6 col-sm-6 col-md-3 col-lg-3">
                 <h5>Step 4</h5>
                 <hr />
                 <a href="/Guides/earn-grc.htm">

--- a/Guides/investor-acquire-grc.htm
+++ b/Guides/investor-acquire-grc.htm
@@ -5,7 +5,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -14,7 +14,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -23,7 +23,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">
@@ -43,7 +43,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -52,7 +52,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -61,7 +61,7 @@ description: "Step 2 of the 'Acquire Gridcoin' guide; Informing users where they
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">

--- a/Guides/investor-earn-grc.htm
+++ b/Guides/investor-earn-grc.htm
@@ -5,7 +5,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -14,7 +14,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -23,7 +23,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">
@@ -39,7 +39,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
 <section class="invester-earnGRC grc-bgcolor" data-background-color="black">
     <div class="container">
             <div class="row">
-                <div class='col-xs-12 col-sm-12 text-center'>
+                <div class='col-12 col-sm-12 text-center'>
                     <h4 class="text-bold">
                         Earn GRC via Proof of Stake
                     </h4>
@@ -48,8 +48,8 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
 
             <!--prereqs-->
             <div class="row">
-                <div class="col-xs-12">
-                    <div class="col-xs-12 col-sm-12 col-md-12">
+                <div class="col-12">
+                    <div class="col-12 col-sm-12 col-md-12">
                         <ul>
                             <li>
                                 <ul>
@@ -77,7 +77,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -86,7 +86,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -95,7 +95,7 @@ description: "Step 3 of the 'Investor mode' guide; Instructing the user how to e
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">

--- a/Guides/investor-gridcoin-setup.htm
+++ b/Guides/investor-gridcoin-setup.htm
@@ -5,7 +5,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -14,7 +14,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -23,7 +23,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">
@@ -39,7 +39,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
 <section class="invest-grc-setup grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row text-center">
-                <div class="col-xs-12 col-sm-8">
+                <div class="col-12 col-sm-8">
                     <h4 class="text-bold">Gridcoin Introduction</h4>
                     <p>The following guides explain how to set up the Gridcoin Research wallet client on the platform of your choice.</p>
                     <p>
@@ -59,7 +59,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
     <div class="container">
         <div class="row">
             <!--
-            <div class="col-xs-12 col-sm-12">
+            <div class="col-12 col-sm-12">
                 <h4>
                 </h4>
                 <p>If you're not interested in earning POS rewards, you can use several third party Gridcoin wallets to hold your GRC off centralized exchanges.</p>
@@ -72,7 +72,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                 <a class="btn btn-simple btn-default" href="https://bitshares.org/">Bitshares-Light</a>
             </div>
           -->
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     Third party multi-wallets for Gridcoin
                 </h5>
@@ -87,7 +87,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/investor-gridcoin-setup.htm">
@@ -96,7 +96,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/investor-acquire-grc.htm">
@@ -105,7 +105,7 @@ description: "Step 1 of the 'Investor mode' guide; Informing the user how to syn
                     </button>
                 </a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 3</h5>
                 <hr />
                 <a href="/Guides/investor-earn-grc.htm">

--- a/Guides/misc.htm
+++ b/Guides/misc.htm
@@ -6,7 +6,7 @@ description: "Miscellaneous BOINC guides sourced from many BOINC community websi
 <section class="grc-misc grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class='row'>
-            <div class='col-xs-12 text-center'>
+            <div class='col-12 text-center'>
                 <h4 class="text-bold">MISC BOINC Guides</h4>
             </div>
         </div>

--- a/Guides/pool-gridcoin-install.htm
+++ b/Guides/pool-gridcoin-install.htm
@@ -5,7 +5,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="grc-bgcolor guide-menu-top" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/pool.htm">
@@ -14,7 +14,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/pool-gridcoin-install.htm">
@@ -30,7 +30,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="grc-bgcolor grclink" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-8 col-md-8">
+            <div class="col-12 col-sm-8 col-md-8">
                 <h4 class="text-bold">Gridcoin Introduction</h4>
                 <ul>
                     <li>
@@ -61,7 +61,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="grc-bgcolor grclink" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 text-center">
+            <div class="col-12 col-sm-12 text-center">
                 <h4>
                     Once the Gridcoin client has been installed, sync the blockchain!
                 </h4>
@@ -70,7 +70,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 
         <!--prereqs-->
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <ul>
                     <li>
                         <ul>
@@ -122,7 +122,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5 class="text-bold">
                   Third party multi-wallets for Gridcoin
                 </h5>
@@ -136,7 +136,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="grc-bgcolor guide-menu-bot" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/pool.htm">
@@ -145,7 +145,7 @@ description: "Step 2 of the 'Pool Crunching' guide; Instructing users how to ins
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/pool-gridcoin-install.htm">

--- a/Guides/pool.htm
+++ b/Guides/pool.htm
@@ -5,7 +5,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="guide-menu-top grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/pool.htm">
@@ -14,7 +14,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5 >Step 2</h5>
                 <hr />
                 <a href="/Guides/pool-gridcoin-install.htm">
@@ -36,7 +36,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
     <!--First row of features-->
         <!--Step 3 banner-->
         <div class='row'>
-            <div class='col-xs-12 text-center' >
+            <div class='col-12 text-center' >
                 <h4 class="text-bold">
                     Sign up to a Gridcoin pool
                 </h4>
@@ -45,7 +45,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
         <!--/Step 3 banner-->
         <!--Step 3 banner-->
         <div class='row'>
-            <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12' >
+            <div class='col-12 col-sm-12 col-md-12 col-lg-12' >
                 <h6>
                     There is currently two pools:
                 </h6>
@@ -66,7 +66,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
 <section class="guide-menu-bot grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 1</h5>
                 <hr />
                 <a href="/Guides/pool.htm">
@@ -75,7 +75,7 @@ description: "Step 1 of the 'Pool Crunching' guide; Instructing users how to ins
                     </button>
                 </a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <h5>Step 2</h5>
                 <hr />
                 <a href="/Guides/pool-gridcoin-install.htm">

--- a/_includes/_acquire.htm
+++ b/_includes/_acquire.htm
@@ -2,7 +2,7 @@
 <section class="acquire-grc grc-bgcolor grclink" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class='col-xs-12 col-sm-12 text-center'>
+            <div class='col-12 col-sm-12 text-center'>
                 <h4 class="text-bold">
                      Sync With the Blockchain
                 </h4>
@@ -10,7 +10,7 @@
         </div>
         <!--prereqs-->
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <ul>
                     <li>
                         Before your wallet can do anything, it needs to be synced (the green tick under connections means you are synced)
@@ -55,7 +55,7 @@
 <section class="acquire-grc grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class='col-xs-12 col-sm-12 text-center'>
+            <div class='col-12 col-sm-12 text-center'>
                 <h4 class="text-bold">
                     Get Some Gridcoin
                 </h4>
@@ -63,7 +63,7 @@
         </div>
         <!--Contibute content-->
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <ul>
                     <li>
                         In Gridcoin's Proof-of-Stake (PoS) system, BOINC rewards are given when users stake, along with an additional 10 GRC.

--- a/_includes/_acquire_details.htm
+++ b/_includes/_acquire_details.htm
@@ -1,7 +1,7 @@
 <section class="acquire-details grc-bgcolor" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12 text-center">
                 <h3 class="text-bold">Ways to Get Gridcoin</h3>
                 <p>If you don't want to buy any Gridcoin, you can get some through the faucets or <a href="/Guides/pool.htm">through pool mining</a>.<br>
                 On most centralized exchanges you need to first <a href="https://www.bitcoin.com/buy-bitcoin">buy Bitcoin</a> in order to buy Gridcoin, except from <a href="https://flyp.me">flyp.me</a> where you can use other cryptocurrencies.</p>
@@ -9,7 +9,7 @@
         </div>
 
         <div class="row text-center">
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4 text-center">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4 text-center">
                 <h3>Free/Starter Gridcoin</h3>
                 <ul>
                     <li>
@@ -32,7 +32,7 @@
                     </li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4">
                 <h3>Decentralized exchanges</h3>
                 <ul>
                     <li>
@@ -49,7 +49,7 @@
                     -->
                 </ul>
            </div>
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4">
                 <h3>Centralized exchanges</h3>
                 <ul>
                     <li>

--- a/_includes/_boinc_1A.htm
+++ b/_includes/_boinc_1A.htm
@@ -3,7 +3,7 @@
     <!--First row of features-->
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-8">
+            <div class="col-12 col-sm-8">
                 <h5>Not interested in earning BOINC rewards?</h5>
                 <p>Switch to the <a href="/Guides/investor-gridcoin-setup.htm">Investor guide</a>. You do not need to install or run BOINC in order to use GRC as a cryptocurrency.</p>
                 <h4 class="text-bold">BOINC Introduction</h4>
@@ -21,18 +21,18 @@
         </div>
 
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <h4 class="text-bold">Install BOINC</h4>
             </div>
         </div>
 
         <!--Step 1-->
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <p>Navigate to the <a href="https://boinc.berkeley.edu">BOINC website</a>, download and install the appropriate BOINC client on each of the computers you wish to crunch BOINC work upon. If you're not crunching projects which require <a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a> you don't need to install BOINC+VirtualBox.</p>
                 <a href="https://boinc.berkeley.edu/download.php"><button class="btn btn-round grcbtn">BOINC client downloads</button></a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 Here's some BOINC installation video tutorials:
                     <ul>
                         <li><a href="https://www.youtube.com/watch?v=SiQ0Ro_bCZY">Pi my life up: Setting up BOINC on a Raspberry Pi</a></li>

--- a/_includes/_boinc_1B.htm
+++ b/_includes/_boinc_1B.htm
@@ -5,7 +5,7 @@
     <!--First row of features-->
         <!--Step 3 banner-->
         <div class="row">
-            <div class="col-xs-12 text-center" >
+            <div class="col-12 text-center" >
                 <h4 class="text-bold">
                     Pros and Cons of Account Managers
                 </h4>
@@ -14,7 +14,7 @@
         <!--/Step 3 banner-->
         <!--Step 3 banner-->
         <div class="row">
-            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" >
+            <div class="col-12 col-sm-6 col-md-6 col-lg-6" >
                 <ul>
                     <li>
                         Choose and follow the instructions for your choice
@@ -47,7 +47,7 @@
         <!--/Step 3 banner-->
         <!--Step 3 content-->
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <h4 class="text-bold">No Account Manager Setup</h4>
                 <ul>
                     <li>
@@ -76,7 +76,7 @@
         </div>
 
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <h4 class="text-bold">BOINC Account Manager Setup</h4>
                 <ul>
                     <li>

--- a/_includes/_boinc_1C.htm
+++ b/_includes/_boinc_1C.htm
@@ -4,7 +4,7 @@
 
         <!--Step 2 banner-->
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <h4 class="text-bold">
                     Choose Projects on the Whitelist
                 </h4>
@@ -12,7 +12,7 @@
         </div>
         <!--/Step 2 banner-->
         <div class="row">
-            <div class="col-xs-12 col-sm-4">
+            <div class="col-12 col-sm-4">
                 <h6>Sources of whitelist data</h6>
                 <ul>
                     <li>
@@ -29,7 +29,7 @@
                     </li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-8">
+            <div class="col-12 col-sm-8">
                 <h6>Project Selection Tips</h6>
                 <ul>
                     <li>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -1,9 +1,9 @@
-<footer class="gridcoin-footer h-100" data-background-color="black">
+<footer class="gridcoin-footer" data-background-color="black">
     <div class="container">
         <div class="row">
             <!--Social links-->
             <div class="col-12 col-sm-3">
-                <a name="Footer"></a> <!-- Link from nav -->              
+                <a name="Footer"></a> <!-- Link from nav -->
                 <ul>
                     <li role="presentation"><h6>Community</h6></li>
                     <li>
@@ -112,7 +112,7 @@
             </div>
             <!--/Social Links-->
             <!--Quick Start Steps-->
-            <div class="col-12 col-sm-3">      
+            <div class="col-12 col-sm-3">
                 <ul>
                     <li role="presentation">
                         <h6>Main Guides</h6>
@@ -127,7 +127,7 @@
                         <a href="/Guides/investor-gridcoin-setup.htm">Investor mode</a>
                     </li>
                 </ul>
-                
+
                 <ul>
                     <li role="presentation"><h6>Guides</h6></li>
                     <li>

--- a/_includes/_solo_boinc_intro.htm
+++ b/_includes/_solo_boinc_intro.htm
@@ -3,7 +3,7 @@
     <!--First row of features-->
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-8">
+            <div class="col-12 col-sm-8">
                 <h5 class="text-bold">Don't Want BOINC rewards?</h5>
                 <p>Switch to the <a href="/Guides/investor-gridcoin-setup.htm">Investor guide</a>. You do not need to install or run BOINC in order to use GRC as a cryptocurrency.</p>
                 <h4 class="text-bold">BOINC Introduction</h4>
@@ -23,18 +23,18 @@
         </div>
 
         <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
                 <h4 class="text-bold">Install BOINC</h4>
             </div>
         </div>
 
         <!--Step 1-->
         <div class="row">
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 <p>Go to the <a href="https://boinc.berkeley.edu">BOINC website</a>, download and install BOINC for any computer you want to run BOINC on. If you don't have projects that use <a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a>, BOINC+VirtualBox is not needed.</p>
                 <a href="https://boinc.berkeley.edu/download.php"><button class="btn btn-round grcbtn">BOINC client downloads</button></a>
             </div>
-            <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
+            <div class="col-6 col-sm-6 col-md-6 col-lg-6">
                 BOINC Installation Video Tutorials:
                     <ul>
                         <li><a href="https://www.youtube.com/watch?v=SiQ0Ro_bCZY">Pi my life up: Setting up BOINC on a Raspberry Pi</a></li>

--- a/_includes/_wallet_install.htm
+++ b/_includes/_wallet_install.htm
@@ -2,7 +2,7 @@
     <div class="container">
         <!--Step 1-->
         <div class="row">
-            <div class="col-xs-12 col-sm-12">
+            <div class="col-12 col-sm-12">
                 <h4 class="text-bold">
                     Install the Gridcoin client
                 </h4>
@@ -15,7 +15,7 @@
                     </li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     Mac OS
                 </h5>
@@ -24,7 +24,7 @@
                     </a>
                     <a class="btn btn-round grcbtn" href="http://wiki.gridcoin.us/OS_X_Guide">Gridcoin wiki: Mac OS guide</a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     Debian Packages (Ubuntu)
                 </h5>
@@ -36,19 +36,19 @@
                     <li>gridcoinresearch</li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     RPM Packages (OpenSUSE/Fedora)
                 </h5>
                 <a class="btn btn-round grcbtn" href="https://software.opensuse.org/package/gridcoinresearch">OpenSuse/Fedora RPMs</a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     AUR (Arch Linux)
                 </h5>
                 <a class="btn btn-round grcbtn" href="https://aur.archlinux.org/packages/gridcoinresearch-qt">Archlinux AUR package</a>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12">
+            <div class="col-12 col-sm-12 col-md-12">
                 <h5>
                     Manually compile the Gridcoin client
                 </h5>

--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -2,16 +2,16 @@
 <html class="h-100" lang="en">
     {% include _head.htm %}
     <body class="h-100">
-    {% include _header.htm %}
-    <div class="min-h-80">{{ content }}</div>
-    {% include _footer.htm %}
+        {% include _header.htm %}
+        <div class="min-h-80">{{ content }}</div>
+        {% include _footer.htm %}
 
-	<!--   Core JS Files   -->
-	<script src="/assets/js/core/jquery-3.4.1.min.js" type="text/javascript"></script>
-	<script src="/assets/js/core/tether.min.js" type="text/javascript"></script>
-	<script src="/assets/js/core/bootstrap.bundle.min.js" type="text/javascript"></script>
-	<!-- Control Center for Now Ui Kit: parallax effects, scripts for the example pages etc -->
-	<script src="/assets/js/now-ui-kit.js" type="text/javascript"></script>
-	<script src="/assets/js/fetch-release.js" type="text/javascript"></script>
-  </body>
+        <!--   Core JS Files   -->
+        <script src="/assets/js/core/jquery-3.4.1.min.js" type="text/javascript"></script>
+        <script src="/assets/js/core/tether.min.js" type="text/javascript"></script>
+        <script src="/assets/js/core/bootstrap.bundle.min.js" type="text/javascript"></script>
+        <!-- Control Center for Now Ui Kit: parallax effects, scripts for the example pages etc -->
+        <script src="/assets/js/now-ui-kit.js" type="text/javascript"></script>
+        <script src="/assets/js/fetch-release.js" type="text/javascript"></script>
+    </body>
 </html>

--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -3,7 +3,7 @@
     {% include _head.htm %}
     <body class="h-100">
     {% include _header.htm %}
-    {{ content }}
+    <div class="min-h-80">{{ content }}</div>
     {% include _footer.htm %}
 
 	<!--   Core JS Files   -->

--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html class="h-100" lang="en">
-	{% include _head.htm %}
-	<body class="h-100 d-flex flex-column">
-	{% include _header.htm %}
-	{{ content }}
-	{% include _footer.htm %}
+    {% include _head.htm %}
+    <body class="h-100">
+    {% include _header.htm %}
+    {{ content }}
+    {% include _footer.htm %}
 
 	<!--   Core JS Files   -->
 	<script src="/assets/js/core/jquery-3.4.1.min.js" type="text/javascript"></script>

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -311,3 +311,6 @@ body {
     font-weight:normal;
   }
   */
+  .min-h-80{
+      min-height: 80%;
+  }

--- a/blog.htm
+++ b/blog.htm
@@ -9,7 +9,7 @@ description: "This blog is for official announcements and important community up
             <div class="hidden-xs col-sm-4 col-md-4 col-lg-4 text-center">
                 <img src="/assets/img/LOGO/GRCLogoOnly_Purple_White_Solid.png" alt="GRC"/>
             </div>
-            <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8 text-center">
+            <div class="col-12 col-sm-8 col-md-8 col-lg-8 text-center">
                 <h3 class="text-bold">Welcome to the official Gridcoin blog!</h3>
                 <p>
                     We'll be posting Gridcoin and BOINC related announcements to this blog so as to improve communication across the entire community.
@@ -27,7 +27,7 @@ description: "This blog is for official announcements and important community up
     <div class="container">
         <div class="row">
             {% for post in site.data.blog.posts %}
-                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                     <h4>{{ post.title }}</h4>
                     <p>{{ post.content }}</p>
                     <a href="{{ post.link_primary_url }}">{{ post.link_primary_text }}</a>

--- a/contact.htm
+++ b/contact.htm
@@ -8,7 +8,7 @@ description: "How to get in contact with the Gridcoin developers and community."
             <div id="grclogo" class="hidden-xs col-sm-4 col-md-4 col-lg-4 text-center">
                 <img src="/assets/img/LOGO/GRCLogoOnly_Purple_White_Solid.png" alt="GRC"  style="width: 200px; " />
             </div>
-            <div class="col-xs-12 col-sm-8 col-md-8 col-lg-8">
+            <div class="col-12 col-sm-8 col-md-8 col-lg-8">
                 <h3 class="text-bold">How to get in contact with us!</h3>
                 <p>Our large userbase is spread across the following chat platforms:</p>
                 <ul>
@@ -32,7 +32,7 @@ description: "How to get in contact with the Gridcoin developers and community."
                     </li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                 <p>If you're looking to report security concerns:</p>
                 <ul>
                     <li>See the official <a href="https://github.com/gridcoin-community/Gridcoin-Research/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" >Gridcoin Security Disclosure Document</a>.</li>

--- a/exchange.htm
+++ b/exchange.htm
@@ -5,14 +5,14 @@ description: "Where to buy Gridcoin"
 <section class="acquire-details grc-bgcolor pt-5 mt-5" data-background-color="black">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                 <h3>How to buy Gridcoin?</h3>
                 <p>On most centralized exchanges you need to first <a href="https://www.bitcoin.com/buy-bitcoin">buy Bitcoin</a> in order to buy Gridcoin, except from <a href="https://flyp.me">Flyp.me</a> where you can exchange several cryptocurrencies for Gridcoin.</p>
             </div>
         </div>
 
         <div class="row text-center">
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4">
                 <h3>Decentralized exchanges</h3>
                 <ul>
                     <li>
@@ -29,7 +29,7 @@ description: "Where to buy Gridcoin"
                     -->
                 </ul>
            </div>
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4">
                 <h3>Centralized exchanges</h3>
                 <ul>
                     <li>
@@ -60,7 +60,7 @@ description: "Where to buy Gridcoin"
                 </ul>
             </div>
 
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
+            <div class="col-12 col-sm-4 col-md-4 col-lg-4">
                 <h3>Free/Starter Gridcoin</h3>
                 <ul>
                     <li>


### PR DESCRIPTION
Updating the bootstrap classes from their V3 versions to V4 fixes the issue with IE11.

I've also added better fix for the 100% height issue on low content pages as suggested by cycy.