### PR TITLE
Formatting and Added a Sitemap to robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,6 @@
-# robotstxt.org/
-
+# All robots allowed
 User-agent: *
+Disallow:
+
+# Sitemap files
+Sitemap: https://gridcoin.us/sitemap.xml


### PR DESCRIPTION
Added a sitemap link and fixes some formatting. A sitemap link being in the robots.txt is recommended practice. Isn't strictly necessary but won't hurt to have.