### PR TITLE
Add contributors link, general repo link

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -74,6 +74,9 @@
                         <a href="https://github.com/gridcoin-community/Gridcoin-Research">Github</a>
                     </li>
                     <li>
+                        <a href="https://github.com/gridcoin-community/Gridcoin-Research/graphs/contributors">Core Wallet Contributors</a>
+                    </li>
+                    <li>
                         <a href="/Dev/rpc-reference.htm">RPC Reference</a>
                     </li>
                     <li>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -53,6 +53,8 @@
                             <a class="dropdown-item" href="https://github.com/gridcoin-community/Gridcoin-Marketing">Gridcoin Marketing and Media Files</a>
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">Development</h6>
+                            <a class="dropdown-item" href="https://github.com/gridcoin-community">Github Repositories</a>
+                            <a class="dropdown-item" href="https://github.com/gridcoin-community/Gridcoin-Research/graphs/contributors">Core Wallet Contributors</a>
                             <a class="dropdown-item" href="/Dev/rpc-reference.htm">RPC Reference</a>
                             <a class="dropdown-item" href="/#Downloads">Wallet Downloads</a>
                             <a class="dropdown-item" href="https://download.gridcoin.us/download/downloadstake/signed/snapshot.zip">Official Snapshot</a>


### PR DESCRIPTION
Added Core Wallet Contributors link to both nav menu and footer under development section
Added a General Repo Link to nav menu under development section.

This follows a discussion on slack about the lack of a team page and such.
This is a start in providing more resources related to the development of gridcoin.