### PR TITLE
Remove Rocket Chat From Footer and Header 

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -25,9 +25,6 @@
                         <a href="https://www.reddit.com/r/gridcoin">Reddit</a>
                     </li>
                     <li>
-                        <a href="https://chat.gridcoin.io/">Rocket chat</a>
-                    </li>
-                    <li>
                         <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/">Slack</a>
                     </li>
                     <li>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -31,7 +31,6 @@
                             <a class="dropdown-item" href="https://t.me/BOINC_Telegram">BOINC Telegram</a>
                             <a class="dropdown-item" href="https://t.me/gridcoin">Gridcoin Telegram</a>
                             <a class="dropdown-item" href="https://discord.gg/jf9XX4a">Discord</a>
-                            <a class="dropdown-item" href="https://chat.gridcoin.io/">Rocket</a>
                             <a class="dropdown-item" href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/">Slack</a>
                             <a class="dropdown-item" href="https://jq.qq.com/?_wv=1027&k=5fDyjCV">Gridcoin 中国 qq 群</a>
                         </div>


### PR DESCRIPTION
Was added in #88 but now the server is down permanently as far as I know. I also used git grep to check that a link to rocket chat wasn't anywhere else only found it in the footer and header. 