### PR TITLE
Remove references to Whaleshares, Fix Slack invite

### DIFF
--- a/_includes/_acquire_details.htm
+++ b/_includes/_acquire_details.htm
@@ -25,7 +25,7 @@
                         Visit <a href="http://uscore.net/">uscore.net</a>, receive GRC by registering for their Gridcoin/BOINC related newsletter.
                     </li>
                     <li>
-                        Join <a href="https://steemit.com/trending/gridcoin">Steemit</a> and <a href="https://whaleshares.io/trending/gridcoin">Whaleshares</a>, post original Gridcoin content then exchange rewards for Gridcoin.
+                        Join <a href="https://steemit.com/trending/gridcoin">Steemit</a> and post original Gridcoin content then exchange rewards for Gridcoin.
                     </li>
                     <li>
                         Work on Gridcoin development bounties. See the lists <a href="https://github.com/gridcoin-community/gridcoin-research/issues?q=is%3Aissue+label%3ABounty+is%3Aopen">here</a> and <a href="https://github.com/gridcoin-community/Gridcoin-Tasks/issues?q=is%3Aopen+is%3Aissue+label%3Abounty">here</a>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -31,9 +31,6 @@
                         <a href="https://steemit.com/trending/gridcoin">Steemit</a>
                     </li>
                     <li>
-                      <a href="https://whaleshares.io/created/gridcoin">Whaleshares</a>
-                    </li>
-                    <li>
                         <a href="https://twitter.com/GridcoinNetwork">Twitter</a>
                     </li>
                     <li>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -25,7 +25,7 @@
                         <a href="https://www.reddit.com/r/gridcoin">Reddit</a>
                     </li>
                     <li>
-                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/">Slack</a>
+                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY">Slack</a>
                     </li>
                     <li>
                         <a href="https://steemit.com/trending/gridcoin">Steemit</a>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -24,7 +24,6 @@
                             <a class="dropdown-item" href="https://github.com/gridcoin-community/Gridcoin-Research">Github</a>
                             <a class="dropdown-item" href="https://www.reddit.com/r/gridcoin">Reddit</a>
                             <a class="dropdown-item" href="https://steemit.com/trending/gridcoin">Steemit</a>
-                            <a class="dropdown-item" href="https://whaleshares.io/created/gridcoin">Whaleshares</a>
                             <a class="dropdown-item" href="https://twitter.com/GridcoinNetwork">Twitter</a>
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">Chat</h6>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -30,7 +30,7 @@
                             <a class="dropdown-item" href="https://t.me/BOINC_Telegram">BOINC Telegram</a>
                             <a class="dropdown-item" href="https://t.me/gridcoin">Gridcoin Telegram</a>
                             <a class="dropdown-item" href="https://discord.gg/jf9XX4a">Discord</a>
-                            <a class="dropdown-item" href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/">Slack</a>
+                            <a class="dropdown-item" href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY">Slack</a>
                             <a class="dropdown-item" href="https://jq.qq.com/?_wv=1027&k=5fDyjCV">Gridcoin 中国 qq 群</a>
                         </div>
                     </div>

--- a/contact.htm
+++ b/contact.htm
@@ -19,7 +19,7 @@ description: "How to get in contact with the Gridcoin developers and community."
                         <a href="https://t.me/gridcoin">Gridcoin's Telegram channel</a>
                     </li>
                     <li>
-                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/" >Gridcoin's Slack channel</a>
+                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY" >Gridcoin's Slack channel</a>
                     </li>
                     <li>
                         <a href="https://discord.gg/jf9XX4a" >Gridcoin's Discord channel</a>

--- a/contact.htm
+++ b/contact.htm
@@ -19,27 +19,27 @@ description: "How to get in contact with the Gridcoin developers and community."
                         <a href="https://t.me/gridcoin">Gridcoin's Telegram channel</a>
                     </li>
                     <li>
-                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY" >Gridcoin's Slack channel</a>
+                        <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY">Gridcoin's Slack channel</a>
                     </li>
                     <li>
-                        <a href="https://discord.gg/jf9XX4a" >Gridcoin's Discord channel</a>
+                        <a href="https://discord.gg/jf9XX4a">Gridcoin's Discord channel</a>
                     </li>
                     <li>
-                        <a href="https://www.reddit.com/r/gridcoin" >/r/gridcoin subreddit</a>
+                        <a href="https://www.reddit.com/r/gridcoin">/r/gridcoin subreddit</a>
                     </li>
                     <li>
-                        <a href="https://steemit.com/created/gridcoin" >#Gridcoin Steemit tag</a>
+                        <a href="https://steemit.com/created/gridcoin">#Gridcoin Steemit tag</a>
                     </li>
                 </ul>
             </div>
             <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                 <p>If you're looking to report security concerns:</p>
                 <ul>
-                    <li>See the official <a href="https://github.com/gridcoin-community/Gridcoin-Research/blob/master/VULNERABILITY_RESPONSE_PROCESS.md" >Gridcoin Security Disclosure Document</a>.</li>
-                    <li>Email "<a href="mailto:contact@gridcoin.us" >contact@gridcoin.us</a>" to get the team's attention.</li>
-                    <li>Jump into the <a href="https://grcinvite.herokuapp.com/" >Slack channel</a> or the <a href="https://t.me/gridcoin" >Telegram channel</a> and ask for an administrator.</li>
+                    <li>See the official <a href="https://github.com/gridcoin-community/Gridcoin-Research/blob/master/VULNERABILITY_RESPONSE_PROCESS.md">Gridcoin Security Disclosure Document</a>.</li>
+                    <li>Email "<a href="mailto:contact@gridcoin.us">contact@gridcoin.us</a>" to get the team's attention.</li>
+                    <li>Jump into the <a href="https://grcinvite.herokuapp.com/">Slack channel</a> or the <a href="https://t.me/gridcoin">Telegram channel</a> and ask for an administrator.</li>
                 </ul>
-                <p>If you have non-critical Gridcoin client issues/bugs you wish to raise awareness of, please <a href="https://github.com/gridcoin-community/Gridcoin-Research/issues" >submit an issue on the GitHub repo</a>.</p>
+                <p>If you have non-critical Gridcoin client issues/bugs you wish to raise awareness of, please <a href="https://github.com/gridcoin-community/Gridcoin-Research/issues">submit an issue on the GitHub repo</a>.</p>
                 <p>If you're interested in collaborating towards Gridcoin's future development, don't hesitate to join Slack/Telegram/Discord/CryptoCurrencyTalk/GitHub to begin working with others on your ideas.</p>
             </div>
         </div>

--- a/exchange.htm
+++ b/exchange.htm
@@ -58,7 +58,7 @@ description: "Where to buy Gridcoin"
                         Visit <a href="http://uscore.net/">uscore.net</a>, receive GRC by registering for their regular Gridcoin/BOINC related newsletter.
                     </li>
                     <li>
-                        Join <a href="https://steemit.com/trending/gridcoin">Steemit</a> and <a href="https://whaleshares.io/trending/gridcoin">Whaleshares</a>, post original Gridcoin content then exchange rewards for Gridcoin.
+                        Join <a href="https://steemit.com/trending/gridcoin">Steemit</a> and post original Gridcoin content then exchange rewards for Gridcoin.
                     </li>
                     <li>
                         Work on Gridcoin development bounties.


### PR DESCRIPTION
This is following a 4-1 vote on the web-dev Slack channel.

We have not had a Gridcoin tagged post on Whaleshares in nearly a month and we are not seeing any real interaction with the userbase.

This change can be easily reverted if the platform sees more activity in the future.