### PR TITLE
Add Other Wiki Pages Menu & Minor Cleanup

### DIFF
--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -5,9 +5,22 @@
         {% include _header.htm %}
         <div class="min-h-80 docs-container conatiner">
             <div class="row">
-                <div class="col-xl-3"></div>
+                <div class="col-xl-3">
+                    <details class="docs-menu">
+                        <summary>Other Wiki Pages (click to view)</summary>
+                        <ul>
+                            {% for page in site.pages %}
+                              {% if page.layout == 'wiki'%}
+                                <li>
+                                  <a href="{{ page.url }}">{{ page.title }}</a>
+                                </li>
+                              {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </details>
+                </div>
                 <div class="col-xl-6">
-                        {{ content  }}
+                    {{ content  }}
                 </div>
             </div>
         </div>
@@ -17,5 +30,6 @@
         <script src="/assets/js/core/jquery-3.4.1.min.js" type="text/javascript"></script>
         <script src="/assets/js/core/bootstrap-4.3.1.bundle.min.js" type="text/javascript"></script>
         <script src="/assets/js/fetch-release.js" type="text/javascript"></script>
+        <script src="/assets/js/details-element-polyfill.js" type="text/javascript"></script>
     </body>
 </html>

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -29,7 +29,6 @@
         <!--   Core JS Files   -->
         <script src="/assets/js/core/jquery-3.4.1.min.js" type="text/javascript"></script>
         <script src="/assets/js/core/bootstrap-4.3.1.bundle.min.js" type="text/javascript"></script>
-        <script src="/assets/js/fetch-release.js" type="text/javascript"></script>
         <script src="/assets/js/details-element-polyfill.js" type="text/javascript"></script>
     </body>
 </html>

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -3,7 +3,7 @@
     {% include _head.htm %}
     <body>
         {% include _header.htm %}
-        <div class="min-h-80 docs-container conatiner">
+        <div class="min-h-80 docs-container container-fluid">
             <div class="row">
                 <div class="col-xl-3">
                     <details class="docs-menu">

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -371,3 +371,9 @@ body {
  .docs-container code{
     white-space:pre;
  }
+
+ .docs-menu{
+     width: 75%;
+     margin: 0px auto 16px auto;
+     /* 16px gives spacing on the bottom on mobile when collapsed*/
+ }

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -347,7 +347,6 @@ body {
   .docs-container{
     padding-top: 130px;
     text-align:left;
-    margin: 0 auto;
   }
   .docs-container table{
     border-collapse: collapse;
@@ -373,7 +372,7 @@ body {
  }
 
  .docs-menu{
-     width: 75%;
+     width: 270px;
      margin: 0px auto 16px auto;
      /* 16px gives spacing on the bottom on mobile when collapsed*/
  }

--- a/assets/js/details-element-polyfill.js
+++ b/assets/js/details-element-polyfill.js
@@ -1,0 +1,194 @@
+/*
+Details Element Polyfill 2.4.0
+Copyright © 2019 Javan Makhmali
+ */
+(function() {
+  "use strict";
+  var element = document.createElement("details");
+  var elementIsNative = typeof HTMLDetailsElement != "undefined" && element instanceof HTMLDetailsElement;
+  var support = {
+    open: "open" in element || elementIsNative,
+    toggle: "ontoggle" in element
+  };
+  var styles = '\ndetails, summary {\n  display: block;\n}\ndetails:not([open]) > *:not(summary) {\n  display: none;\n}\nsummary::before {\n  content: "►";\n  padding-right: 0.3rem;\n  font-size: 0.6rem;\n  cursor: default;\n}\n[open] > summary::before {\n  content: "▼";\n}\n';
+  var _ref = [], forEach = _ref.forEach, slice = _ref.slice;
+  if (!support.open) {
+    polyfillStyles();
+    polyfillProperties();
+    polyfillToggle();
+    polyfillAccessibility();
+  }
+  if (support.open && !support.toggle) {
+    polyfillToggleEvent();
+  }
+  function polyfillStyles() {
+    document.head.insertAdjacentHTML("afterbegin", "<style>" + styles + "</style>");
+  }
+  function polyfillProperties() {
+    var prototype = document.createElement("details").constructor.prototype;
+    var setAttribute = prototype.setAttribute, removeAttribute = prototype.removeAttribute;
+    var open = Object.getOwnPropertyDescriptor(prototype, "open");
+    Object.defineProperties(prototype, {
+      open: {
+        get: function get() {
+          if (this.tagName == "DETAILS") {
+            return this.hasAttribute("open");
+          } else {
+            if (open && open.get) {
+              return open.get.call(this);
+            }
+          }
+        },
+        set: function set(value) {
+          if (this.tagName == "DETAILS") {
+            return value ? this.setAttribute("open", "") : this.removeAttribute("open");
+          } else {
+            if (open && open.set) {
+              return open.set.call(this, value);
+            }
+          }
+        }
+      },
+      setAttribute: {
+        value: function value(name, _value) {
+          var _this = this;
+          var call = function call() {
+            return setAttribute.call(_this, name, _value);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (!wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", true);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      },
+      removeAttribute: {
+        value: function value(name) {
+          var _this2 = this;
+          var call = function call() {
+            return removeAttribute.call(_this2, name);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", false);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      }
+    });
+  }
+  function polyfillToggle() {
+    onTogglingTrigger(function(element) {
+      element.hasAttribute("open") ? element.removeAttribute("open") : element.setAttribute("open", "");
+    });
+  }
+  function polyfillToggleEvent() {
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          var target = mutation.target, attributeName = mutation.attributeName;
+          if (target.tagName == "DETAILS" && attributeName == "open") {
+            triggerToggle(target);
+          }
+        });
+      }).observe(document.documentElement, {
+        attributes: true,
+        subtree: true
+      });
+    } else {
+      onTogglingTrigger(function(element) {
+        var wasOpen = element.getAttribute("open");
+        setTimeout(function() {
+          var isOpen = element.getAttribute("open");
+          if (wasOpen != isOpen) {
+            triggerToggle(element);
+          }
+        }, 1);
+      });
+    }
+  }
+  function polyfillAccessibility() {
+    setAccessibilityAttributes(document);
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          forEach.call(mutation.addedNodes, setAccessibilityAttributes);
+        });
+      }).observe(document.documentElement, {
+        subtree: true,
+        childList: true
+      });
+    } else {
+      document.addEventListener("DOMNodeInserted", function(event) {
+        setAccessibilityAttributes(event.target);
+      });
+    }
+  }
+  function setAccessibilityAttributes(root) {
+    findElementsWithTagName(root, "SUMMARY").forEach(function(summary) {
+      var details = findClosestElementWithTagName(summary, "DETAILS");
+      summary.setAttribute("aria-expanded", details.hasAttribute("open"));
+      if (!summary.hasAttribute("tabindex")) summary.setAttribute("tabindex", "0");
+      if (!summary.hasAttribute("role")) summary.setAttribute("role", "button");
+    });
+  }
+  function eventIsSignificant(event) {
+    return !(event.defaultPrevented || event.ctrlKey || event.metaKey || event.shiftKey || event.target.isContentEditable);
+  }
+  function onTogglingTrigger(callback) {
+    addEventListener("click", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.which <= 1) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+          }
+        }
+      }
+    }, false);
+    addEventListener("keydown", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.keyCode == 13 || event.keyCode == 32) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+            event.preventDefault();
+          }
+        }
+      }
+    }, false);
+  }
+  function triggerToggle(element) {
+    var event = document.createEvent("Event");
+    event.initEvent("toggle", false, false);
+    element.dispatchEvent(event);
+  }
+  function findElementsWithTagName(root, tagName) {
+    return (root.tagName == tagName ? [ root ] : []).concat(typeof root.getElementsByTagName == "function" ? slice.call(root.getElementsByTagName(tagName)) : []);
+  }
+  function findClosestElementWithTagName(element, tagName) {
+    if (typeof element.closest == "function") {
+      return element.closest(tagName);
+    } else {
+      while (element) {
+        if (element.tagName == tagName) {
+          return element;
+        } else {
+          element = element.parentNode;
+        }
+      }
+    }
+  }
+})();


### PR DESCRIPTION
Adds a drop down linking to other wiki pages that's generated dynamically. Also fixes up styling issues caused by a typo. Removes unneeded version fetching JS in wiki pages. Adds a JS polyfill (under MIT even though it doesn't say that at the top of the file) since `<details>` elements don't work on internet explorer. 

This is mostly just to separate some of the stuff of from the RPC page overhaul