### PR TITLE
Make Link Color Brighter

### DIFF
--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -69,7 +69,7 @@ body {
     padding-top: 25px;
 }
 .grclink a {
-    color: #9013FE;
+    color: #3f9bff;
 }
 .text-bold {
     font-weight: bold;
@@ -384,4 +384,8 @@ body {
     z-index: -1;
     /*This adjusts the anchors to account for the navbar and have the dropdown work properly on mobile  
 (doesn't change anything visually except where you scroll to on link#anchor)*/
+ }
+ 
+ .docs-container a{
+     color: #3f9bff;
  }


### PR DESCRIPTION
Increases contrast by making the links brighter to make the links more readable. 

This makes the links meet WCAG accessibility standards for contrast ratio. The links now have a ratio of `5.37 : 1` compared to the previous `2.71 : 1`. The minimum contrast ratio to meet the standards for text is `4.5 : 1`

Additionally, for me these links are now way more readable

 