### PR TITLE
Fix Cutoff Sentence In German Wiki

### DIFF
--- a/Wiki/de/index.md
+++ b/Wiki/de/index.md
@@ -43,7 +43,8 @@ vergeudet.
 
 Gridcoin-Research macht Proof of Work überflüssig.
 Mit dem Wechsel zu Gridcoin-Research und damit zum Proof-of-Stake Algorithmus, wird
-nun nahezu die vollständige Rechenleistung der Wissenschaft zur Verfügung gestellt. Der Anteil der Berechnung welcher
+nun nahezu die vollständige Rechenleistung der Wissenschaft zur Verfügung gestellt. Der Anteil der 
+Rechenleistung welcher der Sicherung der Blockchain dient, ist gering.
 
 
 ## Metrics


### PR DESCRIPTION
This fixes an issue in #244 with a sentence that's cutoff. I believe this conflicts with #246 so I will need to rebase that pull request after this is merged