### PR TITLE
Fix German Wiki Index Page Redirect

### DIFF
--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -2,7 +2,7 @@
 title: Gridcoin Wiki
 layout: wiki-de
 redirect_from:
-  - "/Wiki/de"
+  - "/Wiki/de/"
 ---
 
 ## Gridcoin Einführung


### PR DESCRIPTION
Makes it so that `gridcoin.us/Wiki/de/`redirects since currently only `gridcoin.us/Wiki/de` redirects. Search engines were using the trailing slash at the end so this does actually break that link. Otherwise I wasn't able to find any links that were broken 