### PR TITLE
Update FAQ Formating And Links

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -140,7 +140,7 @@
                         <a href="/guides/terminology.htm">Terminology</a>
                     </li>
                     <li>
-                        <a href="/wiki/faq.html">GRC FAQ</a>
+                        <a href="/wiki/faq.html">Gridcoin FAQ</a>
                     </li>
                 </ul>
                 <ul>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -140,7 +140,7 @@
                         <a href="/guides/terminology.htm">Terminology</a>
                     </li>
                     <li>
-                        <a href="http://wiki.gridcoin.us/FAQ">GRC FAQ</a>
+                        <a href="/wiki/faq.html">GRC FAQ</a>
                     </li>
                 </ul>
                 <ul>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -77,7 +77,7 @@
                             <a class="dropdown-item" href="/guides/security.htm">Security</a>
                             <a class="dropdown-item" href="/guides/misc.htm">Misc. Guides</a>
                             <a class="dropdown-item" href="/guides/terminology.htm">Terminology</a>
-                            <a class="dropdown-item" href="http://wiki.gridcoin.us/FAQ">GRC FAQ</a>
+                            <a class="dropdown-item" href="/wiki/faq.html">GRC FAQ</a>
                         </div>
                     </div>
                     <!--    Trade Links    -->

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -77,7 +77,7 @@
                             <a class="dropdown-item" href="/guides/security.htm">Security</a>
                             <a class="dropdown-item" href="/guides/misc.htm">Misc. Guides</a>
                             <a class="dropdown-item" href="/guides/terminology.htm">Terminology</a>
-                            <a class="dropdown-item" href="/wiki/faq.html">GRC FAQ</a>
+                            <a class="dropdown-item" href="/wiki/faq.html">Gridcoin FAQ</a>
                         </div>
                     </div>
                     <!--    Trade Links    -->

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -385,7 +385,9 @@ body {
     /*This adjusts the anchors to account for the navbar and have the dropdown work properly on mobile  
 (doesn't change anything visually except where you scroll to on link#anchor)*/
  }
- 
+ .docs-container hr{
+    border-top: 1px solid #fff
+ } 
  .docs-container a{
      color: #3f9bff;
  }

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -12,10 +12,13 @@ You will see a lot of references to the data folder in this FAQ here are the def
 | Windows | Linux | MacOS |
 |-|-|-|
 | `%appdata%/GridcoinResearch` | `~/.GridcoinResearch` | `~/Library/Application Support/GridcoinResearch` |
+ 
+<br> {% comment %} normal newline (from two spaces) doesn't work after a table for some reason {% endcomment %}
 
 # Gridcoin & Science
 
-## Why is Gridcoin (GRC) special?
+---
+### Why is Gridcoin (GRC) special?
 
 Almost all of your computing power can be directed at beneficial scientific and medical
 research while crunching Gridcoin.
@@ -23,7 +26,8 @@ research while crunching Gridcoin.
 See the list of [Advantages &
 Features](advantages&features "wikilink").
 
-## How could 'useful' work for a cryptocurrency be verified without repeating the work or trusting a central server?
+---
+### How could 'useful' work for a cryptocurrency be verified without repeating the work or trusting a central server?
 
 In Gridcoin, work units are given out by distributed project nodes
 within the BOINC network which uses their independent calculation to
@@ -41,15 +45,17 @@ removed by a blockchain vote.
 Security in Gridcoin is derived from Blackcoin's industry-leading
 Proof-of-Stake.
 
+---
 # Crunching (Research & Mining Equivalent)
 
-## How do I start crunching?
-
+---
+### How do I start crunching?
 Consult these guides: 
 * [Solo](../guides/boinc-install.htm)
 * [Pool](../guides/pool.htm)
 
-## My CPID is not in the network, What do I do?
+---
+### My CPID is not in the network, What do I do?
 
 If you are in the pool, this is normal. If you are attempting to
 solo-stake, go through the following:
@@ -78,32 +84,38 @@ CPID isn't included after a few superblocks, try resending your beacon
 Lock your wallet again, but this time unlock it with "for staking only"
 ticked.
 
-## What should I put in my config-file for Gridcoin-Research?
+---
+### What should I put in my config-file for Gridcoin-Research?
 
 Please check [the config file page](config-file "wikilink")
 
-## How can I tell if I've mined a block?
+---
+### How can I tell if I've mined a block?
 
 If you are using the GUI you will see a transaction with a gold icon. 
 
 You can also lookup your address on a block explorer.
 
-## Reward calculation: what is RAC?
+---
+### Reward calculation: what is RAC?
 
 <https://en.wikipedia.org/wiki/BOINC_Credit_System#Recent_average_credit>
 
-## Reward calculation: what is magnitude?
+---
+### Reward calculation: what is magnitude?
 
 Magnitude is calculated separately for each project. When calculating research rewards, a user's magnitude across every project is added together.
 
-## I had a magnitude for some time but it dropped to 0. What happened?
+---
+### I had a magnitude for some time but it dropped to 0. What happened?
 
 The reason for this is most likely that you have to resend your beacon,
 which should be done every 6 months. For this either unlock your wallet
 so that it sends automatically or type `advertisebeacon` in the
 console.
 
-## I am BOINCing nonstop but my magnitude is very low. What can I do?
+---
+### I am BOINCing nonstop but my magnitude is very low. What can I do?
 
 RAC is a rolling average over the past month. It is weighted to increase the value of more recent contributions. Gridcoin relies on the RAC values provided by the project to calculate your magnitude. 
 
@@ -127,39 +139,47 @@ spirit up.
 Additionally, you might not want to use your CPU to crunch for projects with GPU WUs.
 You can find CPU only projects by visiting the [BOINC project list](https://boinc.berkeley.edu/projects.php) and looking out for projects that have the Radeon or Nvidia icon.
 
+---
 # Pool Crunching
 
-## Is it possible to join a pool?
+---
+### Is it possible to join a pool?
 
 Yes, there are currently 2 operational pools:
 * [GRCPool](https://grcpool.com/)
 * [Arikado Pool](https://grc.arikado.ru/)
 
-## I am crunching for the pool but the wallet still shows INVESTOR and 0 magnitude. Is that ok?
+---
+### I am crunching for the pool but the wallet still shows INVESTOR and 0 magnitude. Is that ok?
 
 That is perfectly normal when pool-mining you do work for the pool's
 account and as a reward get transactions from the pool for the work you
 did. Because of this you do not work for your own CPID and have no
 magnitude.
 
-## I am crunching for the pool but even though I work on projects this is not shown on the profile page of the pool. What can I do?
+---
+### I am crunching for the pool but even though I work on projects this is not shown on the profile page of the pool. What can I do?
 
 Make sure you remove all existing projects, which use your account, from the BOINC manager before
 syncing to the pool. 
 
+---
 # Staking
 
-## How is the amount of stake-reward calculated?
+---
+### How is the amount of stake-reward calculated?
 
 Proof of Stake rewards will give you 10 GRC for each block you stake. If you are not in investor mode you will also receive your BOINC rewards on top of the 10 in the same block.
 
-## The wallet says "Not Staking because you don't have mature coins", how long does it take for coins to mature?
+---
+### The wallet says "Not Staking because you don't have mature coins", how long does it take for coins to mature?
 
 It takes 16 hours for GRC to become mature from the time of
 arrival in your wallet. After a specific set of coins have Staked, they
 will need to mature again for 16 hours before they can Stake again.
 
-## Why can't I send coins in my wallet balance?
+---
+### Why can't I send coins in my wallet balance?
 
 You may have a balance reserved in stake. If this ever happens to you do
 this in the console:
@@ -173,11 +193,13 @@ Wait for a few blocks
 Then send
 it.
 
-## When I get an interest/mining payment, a portion of my GRC looks to be moving from my total balance into the "Stake" line of the wallet balance. Is that correct?
+---
+### When I get an interest/mining payment, a portion of my GRC looks to be moving from my total balance into the "Stake" line of the wallet balance. Is that correct?
 
 Yes. It means that those coins are currently on cooldown so they aren't able to stake for the next 16 hours.
 
-## Can I stake with an encrypted wallet?
+---
+### Can I stake with an encrypted wallet?
 
 Yes, but you have to unlock it first. It's recommended to unlock it "for
 staking only".
@@ -201,7 +223,8 @@ to unlock only for staking type
 
 `walletpassphrase PASSWORD TIMEOUT true`
 
-## How do you turn staking on and off?
+---
+### How do you turn staking on and off?
 
 `walletpassphrase "your passphrase in double quotes" timeout true`
 
@@ -209,20 +232,24 @@ where timeout is the number of seconds, e.g. 10000 and true is a toggle
 that unlocks the wallet for staking
 only.
 
-## What happens if I stake on a fork?
+---
+### What happens if I stake on a fork?
 
 When you stake on a fork, the stake you see is not actually legitimate. When your wallet figures out that it is on a fork, you will see these rewards disappear as the wallet corrects itself. This process happens automatically. While frustrating, once off of the fork, you are still able to stake again. 
 
+---
 # BOINC
 
-## Choosing BOINC projects: In BOINC, is there still a defined whitelist of "projects" or can we use any project now that has Gridcoin as a Team Name?
+---
+### Choosing BOINC projects: In BOINC, is there still a defined whitelist of "projects" or can we use any project now that has Gridcoin as a Team Name?
 
 Running "projects" in the console will list all the whitelisted
 projects you could possibly contribute to that would help your Gridcoin
 Research
 wallet.
 
-## If it says "non participating project" does that mean that they aren't accepted for Gridcoin purposes?
+---
+### If it says "non participating project" does that mean that they aren't accepted for Gridcoin purposes?
 
 That means you aren't participating in those projects or the e-mail
 address you have in the conf file doesn't match the e-mail address used
@@ -232,7 +259,8 @@ e-mail address on a project or team membership on a project take around
 a day to
 propagate.
 
-## I use BOINC with one username but on a few machines - is it enough to have one wallet with the proper boinc\_project\_email address, or do I have to have a separate wallet on each machine?
+---
+### I use BOINC with one username but on a few machines - is it enough to have one wallet with the proper boinc\_project\_email address, or do I have to have a separate wallet on each machine?
 
 You only need one wallet for each BOINC account/CPID (Cross Project
 Identifier). Optionally, you can use an account manager to help maintain
@@ -248,11 +276,13 @@ machine (press "Update" in the BOINC software when a project which shows
 0 contribution is
 selected).
 
-## Instead of discussing every single BOINC project to be added, is there any shared guidelines to be used for accepting or rejecting them?
+---
+### Instead of discussing every single BOINC project to be added, is there any shared guidelines to be used for accepting or rejecting them?
 
 https://github.com/gridcoin-community/Gridcoin-Tasks/issues/227
 
-## How do I delete a project from my list of CPIDs?
+---
+### How do I delete a project from my list of CPIDs?
 
 We used to support detaching but a vote was made to calculate the magnitude
 on every project you still have valid RAC on; so GRC does not support
@@ -263,9 +293,11 @@ account equally.
 If you insist on not being paid for a specific project, change your team
 away from a recognised team for that project.
 
+---
 # Status
 
-## How can I see my Researching Status?
+---
+### How can I see my Researching Status?
 
 If you have some BOINC credits, you are in a recognised team and your email
 is correct in the gridcoinresearch.conf file. You should see a list of
@@ -274,7 +306,8 @@ your magnitude in each project when entering "*explainmagnitude*" to
 the debug console of the wallet (Help -\> Debug Window -\> Console). It
 may take 24-48 hours for new accounts to be populated.
 
-## What does "diff" exactly measure? What does it tell if it's high or low?
+---
+### What does "diff" exactly measure? What does it tell if it's high or low?
 
 A staking hash that is generated that is LESS than the target will stake. So the smaller the target (higher the diff) the LOWER the probability of staking. 
 
@@ -285,7 +318,8 @@ When more coins are staking the difficulty increases which makes it harder to st
 
 The formulas to calculate diff may be found in section 2.1 of the [bluepaper](https://www.gridcoin.world/GRC_V8_Bluepaper_ETTS%20final.pdf).
 
-## How to call commands when starting Gridcoin Wallet on Windows?
+---
+### How to call commands when starting Gridcoin Wallet on Windows?
 
 Create a shortcut that links to the actual GRC program in Program Files
 directory and add the function at the end of the target, then properly
@@ -307,7 +341,8 @@ Line function.
 This way it is simpler and faster for newbies than CLI and
 batch.
 
-## How could I check whether my local block is the same as on an explorer?
+---
+#### How could I check whether my local block is the same as on an explorer?
 
 After you double click on the tx in the list, write down the block
 number (not hash).
@@ -327,21 +362,26 @@ getblock blockhash
 
 But that is a little longer
 
+---
 # Upgrade
 
-## How do I upgrade the Gridcoin wallet client?
+---
+### How do I upgrade the Gridcoin wallet client?
 
 Download the installer from [Github](https://github.com/gridcoin-community/Gridcoin-Research/releases) or your package manager and install over your previous installation.
 
 **Do not delete the data folder.** This contains important data like your keys which let you access your coins.
 
+---
 # Backup
 
-## What can I do if I didn't save a prior version of wallet.dat?
+---
+### What can I do if I didn't save a prior version of wallet.dat?
 
 The wallet has an automated backup in place that will make backups every 24 hours into the walletbackups folder inside of your data folder.
-
-## Which is the best practice to save my new wallet?
+  
+---
+### Which is the best practice to save my new wallet?
 
 Different methods were discussed in the Gridcoin Community Classroom
 \#003: <https://www.youtube.com/watch?v=JxrjUwX5XvA>
@@ -349,7 +389,8 @@ Different methods were discussed in the Gridcoin Community Classroom
 ref:
 <https://cryptocurrencytalk.com/topic/1331-new-coin-launch-announcement-grc-gridcoin/?view=findpost&p=158422>
 
-## How to compress my wallet getting rid of orphans?
+---
+### How to compress my wallet getting rid of orphans?
 
 The quick and easy way.
 
@@ -364,7 +405,8 @@ The quick and easy way.
     somethingelse.bak to wallet.dat
 8.  Start the client and enjoy your new wallet.
 
-## What should I do to recover an old backup of my wallet?
+---
+### What should I do to recover an old backup of my wallet?
 
 1. Backup wallet.dat.
 2. Look for the walletbackups folder.
@@ -375,9 +417,11 @@ The quick and easy way.
 
 If it still doesn't start you can try using the -salvagewallet flag.
 
+---
 # Sync
 
-## I have lots of connections, but synchronizing stopped at a certain block. What should I do?
+---
+### I have lots of connections, but synchronizing stopped at a certain block. What should I do?
 
 Just try to just wait it out the wallet should automatically fix itself.
 
@@ -394,7 +438,8 @@ There is also an [official
 thread](https://cryptocointalk.com/topic/20303-gridcoin-proof-of-research-connection-sync-problem-thread/)
 for sync problem if it didn't work.
 
-## How could I test whether I am in sync with the network?
+---
+### How could I test whether I am in sync with the network?
 
 Compare your highest block number with the one listed at
 [gridcoinstats.eu](https://gridcoinstats.eu/block)
@@ -407,7 +452,8 @@ When you are clearly ahead of the explorer and / or the explorer has
 stopped incrementing on a regular basis, it's more likely that the
 explorer will sync up with you and your connected nodes at some point.
 
-## How do I get in sync fast?
+---
+### How do I get in sync fast?
 
 Ensure you are running the latest wallet version.
 
@@ -418,7 +464,8 @@ While it downloads, delete the peers.dat in your data folder - you may have a ba
 You can also try to reboot your router to attempt to get a new IP, to make sure
 you are not banned by good nodes because of earlier behavior.
 
-## I can't get connections. How can I test whether the net is down or my node is misconfigured?
+---
+### I can't get connections. How can I test whether the net is down or my node is misconfigured?
 
 First, install telnet for your respective os.
 
@@ -427,16 +474,19 @@ port. Otherwise, your configuration might be wrong or your node may have been
 temporarily banned by the
 network.
 
-## When syncing from zero, the sync gets stuck or pauses for an untimely duration. What to do next?
+---
+### When syncing from zero, the sync gets stuck or pauses for an untimely duration. What to do next?
 
 Make sure you're on the latest wallet version.
 
 Syncing may seem to take longer with growing blockchain. If you get
 stuck use 'reboot client'
 
+---
 # Gridcoin Classic
 
-## What is Gridcoin Classic
+---
+### What is Gridcoin Classic
 
 Gridcoin Classic was the first iteration of Gridcoin. Gridcoin classic
 is no longer used and all coins were converted to Gridcoin Research
@@ -444,26 +494,32 @@ coins via Proof of Burn. The Burn process ended on April 20, 2015. If you
 missed the Burn deadline, your coins are now in the possession of the
 Gridcoin Foundation and can no longer be claimed.
 
+---
 # Development
 
-## Where can I find the source?
+---
+### Where can I find the source?
 
 [On Github](https://github.com/gridcoin-community/Gridcoin-Research)
 
-## How could I participate in testnet?
+---
+### How could I participate in testnet?
 
 Start the client with the -testnet flag.
 
 [More info can be found here.](testnet "wikilink")
 
+---
 # Troubleshoot
 
-## Some of my coins have disappeared.
+---
+### Some of my coins have disappeared.
 
 Try running the client with "-rescan" or run the console command
 "repairwallet".
 
-## How to get out of the loop of cycling app crashes (Microsoft Visual C++ Runtime Library Assertion failed)?
+---
+### How to get out of the loop of cycling app crashes (Microsoft Visual C++ Runtime Library Assertion failed)?
 
 Delete the content of the folder called 'txleveldb' in
 the data folder and restart.

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -8,6 +8,7 @@ redirect_from:
 # Frequently Asked Questions
 
 You will see a lot of references to the data folder in this FAQ here are the default locations:
+
 | Windows | Linux | MacOS |
 |-|-|-|
 | `%appdata%/GridcoinResearch` | `~/.GridcoinResearch` | `~/Library/Application Support/GridcoinResearch` |

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -7,7 +7,7 @@ redirect_from:
 
 # Frequently Asked Questions
 
-You will see a lot of references to the data folder in this FAQ here are the default locations:
+You will see a lot of references to the data folder in this FAQ. Here are the default locations:
 
 | Windows | Linux | MacOS |
 |-|-|-|
@@ -316,7 +316,7 @@ This also means that diff is directly proportional to that average net coins sta
 TL;DR:
 When more coins are staking the difficulty increases which makes it harder to stake and vice versa.
 
-The formulas to calculate diff may be found in section 2.1 of the [bluepaper](https://www.gridcoin.world/GRC_V8_Bluepaper_ETTS%20final.pdf).
+The formulas to calculate diff may be found in section 2.1 of the [staking bluepaper](/assets/img/grc-bluepaper-section-1.pdf).
 
 ---
 ### How to call commands when starting Gridcoin Wallet on Windows?


### PR DESCRIPTION
Changes the links in the header and footer to go to the new /wiki/faq.html instead of wiki.gridcoin.us/FAQ which just redirects to the github wiki (not even the FAQ page) where the wiki page there is out of date. 

Updates the formatting to make the long headers smaller and put horizontal rules between each question to better separate them. Also fixes a missed newline to make the markdown table on the faq page work.  It also updates the bluepaper link to be on site and adds a missing period