### PR TITLE
Wiki: Create Page List Page

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,5 +1,5 @@
 ---
-title: Gridcoin Wiki
+title: Gridcoin Wiki Home
 layout: wiki
 redirect_from:
   - "/Wiki/"
@@ -110,6 +110,7 @@ scientific computations instead of securing the blockchain.
 
 ## Official Resources
   <!-- TODO: [Volunteers, Roles & Privileges](Volunteers,-Roles,-&-Privileges "wikilink") -->
+  - [Other Wiki Pages](pages "wikilink")
   - [Website](https://gridcoin.us/)
   - [BOINCstats](https://boincstats.com/en/stats/-1/team/detail/118094994/overview)
   - [Netsoft](http://www.boinc.netsoft-online.com/e107_plugins/boinc/bp_home.php)

--- a/wiki/pages.md
+++ b/wiki/pages.md
@@ -1,0 +1,43 @@
+---
+title: Gridcoin Wiki Pages
+layout: wiki
+---
+
+# Wiki Pages
+
+List of Gridcoin wiki pages in all languages.  
+Pages in your current language can also be seen in the sidebar on the left (on desktop) or above (on mobile)
+
+{% comment %} 
+
+The code below for each language just loops through all the pages and creates a 
+bullet point if the page is a wiki page and in that language. The bullet point
+create a link to the wiki page and uses the page's title for the link text.
+
+To add in another language, create a new header and copy the code and change 
+the string compared to page.layout so it's the layout for the other language
+Example: if page.layout == 'wiki' -> if page.layout == 'wiki-de'
+
+{% endcomment %}
+
+
+## English
+
+{% for page in site.pages %}
+    {% if page.layout == 'wiki'%}
+
+* [ {{page.title}} ]( {{page.url}} )
+
+    {% endif %}
+{% endfor %}
+
+
+## Deutsch (German)
+
+{% for page in site.pages %}
+    {% if page.layout == 'wiki-de'%}
+
+* [ {{page.title}} ]( {{page.url}} )
+
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
Creates a page that lists all wiki pages in all languages. This helps link people to a list of existing pages without having to explain about the sidebar and lets people see the list in all languages

Also clarifies the index page title to be `Gridcoin Wiki Home` so it's more clear than `Gridcoin Wiki` on the sidebar and the page list page 

Looks like this:
![image](https://user-images.githubusercontent.com/30132912/90959148-231ba480-e467-11ea-832b-a631bc6c04cc.png)
