### PR TITLE
Main Page: Add Direct Download Links For Windows

### DIFF
--- a/assets/js/fetch-release.js
+++ b/assets/js/fetch-release.js
@@ -7,20 +7,43 @@ function getLatestRelease() {
         success: function(data) { 
             $('#wallet-version').text('Current Wallet Version: ' + data.name); 
             
-            String.prototype.endsWith = "".endsWith || function(s){return !this.split(s).pop();} //IE11 support
+            String.prototype.includes = String.prototype.includes || function(val, start){'use strict';return this.indexOf(val, start) !== -1;};
+            //IE11 support
+
+            var has64BitHotfix = false;
+            var has32BitHotfix = false;
 
             data.assets.forEach(function(assetFile) {
+                
+                const name = assetFile.name;
+                const downloadURL = assetFile.browser_download_url;
 
-                if (assetFile.name.endsWith("win64-setup.exe") || assetFile.name.endsWith("win64-setup-hotfix.exe")){ 
-                    //hotfixes come after in alphabetical order so the link will end up being the hotfix over the non-hotfix
+                if (name.includes(".SHA256")){
+                    //ignore the checksums (note can't use "continue" so else if statements are used)
+                }
 
-                    $('#64-bit-windows').attr('href', assetFile.browser_download_url).show()
+                else if (name.includes("win64") && name.includes("hotfix")){
+
+                    has64BitHotfix = true;
+                    $('#64-bit-windows').attr('href', downloadURL).show();
+
+                } 
+                else if (name.includes("win64") && !has64BitHotfix){ 
+
+                    $('#64-bit-windows').attr('href', downloadURL).show()
 
                 } 
 
-                if (assetFile.name.endsWith("win32-setup.exe") || assetFile.name.endsWith("win32-setup-hotfix.exe")){
 
-                    $('#32-bit-windows').attr('href', assetFile.browser_download_url).show()
+                else if (name.includes("win32") && name.includes("hotfix")){
+                    
+                    has32BitHotfix = true;
+                    $('#32-bit-windows').attr('href', downloadURL).show();
+                    
+                }
+                else if (name.includes("win32") && !has32BitHotfix){
+
+                    $('#32-bit-windows').attr('href', downloadURL).show()
 
                 }
             });

--- a/assets/js/fetch-release.js
+++ b/assets/js/fetch-release.js
@@ -5,7 +5,24 @@ function getLatestRelease() {
         crossDomain: true,
         dataType: 'json',
         success: function(data) { 
-            $('#wallet-version').text('Current Wallet Version: ' + data['name']); 
+            $('#wallet-version').text('Current Wallet Version: ' + data.name); 
+            
+            String.prototype.endsWith = "".endsWith || function(s){return !this.split(s).pop();} //IE11 support
+
+            data.assets.forEach(function(assetFile) {
+
+                if (assetFile.name.endsWith("win64-setup.exe")){
+
+                    $('#64-bit-windows').attr('href', assetFile.browser_download_url).show()
+
+                } 
+
+                if (assetFile.name.endsWith("win32-setup.exe")){
+
+                    $('#32-bit-windows').attr('href', assetFile.browser_download_url).show()
+
+                }
+            });
         }
     });
 }

--- a/assets/js/fetch-release.js
+++ b/assets/js/fetch-release.js
@@ -11,13 +11,14 @@ function getLatestRelease() {
 
             data.assets.forEach(function(assetFile) {
 
-                if (assetFile.name.endsWith("win64-setup.exe")){
+                if (assetFile.name.endsWith("win64-setup.exe") || assetFile.name.endsWith("win64-setup-hotfix.exe")){ 
+                    //hotfixes come after in alphabetical order so the link will end up being the hotfix over the non-hotfix
 
                     $('#64-bit-windows').attr('href', assetFile.browser_download_url).show()
 
                 } 
 
-                if (assetFile.name.endsWith("win32-setup.exe")){
+                if (assetFile.name.endsWith("win32-setup.exe") || assetFile.name.endsWith("win32-setup-hotfix.exe")){
 
                     $('#32-bit-windows').attr('href', assetFile.browser_download_url).show()
 

--- a/index.htm
+++ b/index.htm
@@ -271,6 +271,13 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             <!--GRC Research Downloads-->
             <div class="col-12 col-sm-6">
               <h4>Windows & Linux</h4>
+              <!-- the 64/32 bit windows direct links won't be displayed while loading -->
+              <a id="64-bit-windows" class="btn rounded-pill grcbtn m-1" style="display:none"> 
+                64-bit Windows
+              </a><br>
+              <a id="32-bit-windows" class="btn rounded-pill grcbtn m-1" style="display:none">
+                32-bit Windows
+              </a><br>
               <a class="btn rounded-pill grcbtn m-1" href="https://github.com/gridcoin-community/Gridcoin-Research/releases/latest">
                   Download via GitHub
               </a><br />


### PR DESCRIPTION
Doesn't show direct links if they are missing from the assets from GitHub or loading and waiting for GitHub's response. 
Linux ones could be added in the future.

Currently hosting this on my fork at https://roboticmind.github.io