### PR TITLE
Remove Links To Coinomi

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -207,9 +207,6 @@
                         <h6>3rd party wallets</h6>
                     </li>
                     <li>
-                        <a href="https://coinomi.com/">Coinomi</a>
-                    </li>
-                    <li>
                         <a href="https://holytransaction.com/">HolyTransaction</a>
                     </li>
                 </ul>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -97,7 +97,6 @@
                             <a class="dropdown-item" href="https://txbit.io/Asset/GRC">Txbit.io</a>
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">3rd party wallets</h6>
-                            <a class="dropdown-item" href="https://coinomi.com/">Coinomi</a>
                             <a class="dropdown-item" href="https://holytransaction.com/">HolyTransaction</a>
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">Where to spend</h6>

--- a/guides/investor-gridcoin-setup.htm
+++ b/guides/investor-gridcoin-setup.htm
@@ -79,7 +79,6 @@ redirect_from:
                     Third party multi-wallets for Gridcoin
                 </h5>
                 <a class="btn btn-round grcbtn" href="https://holytransaction.com/">HolyTransaction</a>
-                <a class="btn btn-round grcbtn" href="https://coinomi.com/">Coinomi</a>
             </div>
         </div>
 

--- a/guides/pool-gridcoin-install.htm
+++ b/guides/pool-gridcoin-install.htm
@@ -129,7 +129,6 @@ redirect_from:
                   Third party multi-wallets for Gridcoin
                 </h5>
                 <a href="https://holytransaction.com/"><button class="btn btn-round grcbtn">HolyTransaction</button></a>
-                <a href="https://coinomi.com/"><button class="btn btn-round grcbtn">Coinomi</button></a>
             </div>
         </div>
     </div>

--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -155,7 +155,6 @@ energieeffizienter ist als der Proof of Work Algorithmus. Nutzer können zusätz
 <!-- end list -->
 
   - 3rd-Party Wallets:
-      - [Coinomi](https://coinomi.com/)
       - [HolyTransaction](https://holytransaction.com/)
 
 <!-- end list -->

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -163,7 +163,6 @@ scientific computations instead of securing the blockchain.
 <!-- end list -->
 
   - 3rd-Party wallets:
-      - [Coinomi](https://coinomi.com/)
       - [HolyTransaction](https://holytransaction.com/)
 
 <!-- end list -->


### PR DESCRIPTION
Since Coinomi no longer supports Gridcoin, the links to it should be removed from the site. 

This should hopefully cover all the links. I have searched with my IDE and with `git grep` and these were all the links that I found.