### PR TITLE
Add Bluepaper Links To Header & Footer

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -149,6 +149,9 @@
                         <a href="/assets/img/whitepaper.pdf">Whitepaper</a>
                     </li>
                     <li>
+                        <a href="/assets/img/grc-bluepaper-section-1.pdf">Gridcoin Staking Bluepaper</a>
+                    </li>
+                    <li>
                         <a href="https://boinc.berkeley.edu/wiki/Publications_by_BOINC_projects">BOINC Project Publications</a>
                     </li>
                     <li>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -42,6 +42,7 @@
                         <div class="dropdown-menu" aria-labelledby="resource-dropdown">
                             <h6 class="dropdown-header text-center">Publications</h6>
                             <a class="dropdown-item" href="/assets/img/whitepaper.pdf">Gridcoin Whitepaper</a>
+                            <a class="dropdown-item" href="/assets/img/grc-bluepaper-section-1.pdf">Gridcoin Staking Bluepaper</a>
                             <a class="dropdown-item" href="https://boinc.berkeley.edu/wiki/Publications_by_BOINC_projects">BOINC Project Publications</a>
                             <a class="dropdown-item" href="https://scholar.google.co.uk/scholar?q=BOINC">BOINC Academic Articles</a>
                             <div class="dropdown-divider"></div>


### PR DESCRIPTION
Adds them in the publications section where the whitepaper is linked