### PR TITLE
Whitelist: Correct That Minecraft@Home Doesn't Have CPU Tasks

### DIFF
--- a/_data/whitelist.yml
+++ b/_data/whitelist.yml
@@ -95,7 +95,7 @@ projects:
   goal: Enables the study of the fundamental laws of Minecraft to answer 
         unanswered questions regarding the features and true limits of the game.
   sponsor: Private
-  cpu: 'yes'
+  cpu: 'no'
   gpu: 'yes'
   gdpr: 'no'
   team: https://minecraftathome.com/minecrafthome/team_display.php?teamid=1840


### PR DESCRIPTION
I mistakenly put in #279 that Minecraft@Home has CPU tasks, but it does not. Fixes that here 