### PR TITLE
General: Remove Cryptocurrencytalk Links

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -13,9 +13,6 @@
                         <a href="/contact.htm">Contact Us</a>
                     </li>
                     <li>
-                        <a href="https://cryptocurrencytalk.com/forum/464-gridcoin-grc/">Cryptocurrency talk</a>
-                    </li>
-                    <li>
                         <a href="https://discord.gg/jf9XX4a">Discord</a>
                     </li>
                     <li>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -21,7 +21,6 @@
                             <a class="dropdown-item" href="/blog.htm">Blog</a>
                             <a class="dropdown-item" href="/contact.htm">Contact Us</a>
                             <a class="dropdown-item" href="https://www.facebook.com/gridcoins">Facebook</a>
-                            <a class="dropdown-item" href="https://cryptocurrencytalk.com/forum/464-gridcoin-grc/">Forum</a>
                             <a class="dropdown-item" href="https://github.com/gridcoin-community/Gridcoin-Research">Github</a>
                             <a class="dropdown-item" href="https://www.reddit.com/r/gridcoin">Reddit</a>
                             <a class="dropdown-item" href="https://steemit.com/trending/gridcoin">Steemit</a>

--- a/contact.htm
+++ b/contact.htm
@@ -13,9 +13,6 @@ description: "How to get in contact with the Gridcoin developers and community."
                 <p>Our large userbase is spread across the following chat platforms:</p>
                 <ul>
                     <li>
-                        <a href="https://cryptocurrencytalk.com/forum/464-gridcoin-grc/">CryptoCurrencyTalk - Gridcoin Subforum</a>
-                    </li>
-                    <li>
                         <a href="https://t.me/gridcoin">Gridcoin's Telegram channel</a>
                     </li>
                     <li>
@@ -40,7 +37,7 @@ description: "How to get in contact with the Gridcoin developers and community."
                     <li>Jump into the <a href="https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTE4N2I3ZWZjYWJlZGM1Zjg3MTUyMDhiN2M5NmRmZTA2NDA0ZmY1ZTFmOGM3ZGU2YTBkOTdhNTk2ZjkzMGZkODY/">Slack channel</a> or the <a href="https://t.me/gridcoin">Telegram channel</a> and ask for an administrator.</li>
                 </ul>
                 <p>If you have non-critical Gridcoin client issues/bugs you wish to raise awareness of, please <a href="https://github.com/gridcoin-community/Gridcoin-Research/issues">submit an issue on the GitHub repo</a>.</p>
-                <p>If you're interested in collaborating towards Gridcoin's future development, don't hesitate to join Slack/Telegram/Discord/CryptoCurrencyTalk/GitHub to begin working with others on your ideas.</p>
+                <p>If you're interested in collaborating towards Gridcoin's future development, don't hesitate to join Slack/Telegram/Discord/GitHub to begin working with others on your ideas.</p>
             </div>
         </div>
     </div>

--- a/guides/whitelist.htm
+++ b/guides/whitelist.htm
@@ -12,17 +12,15 @@ redirect_from:
                 <div class="col-12 col-sm-4">
                     <h5>Whitelist justification</h5>
                     <p>The whitelist was created to increase security and to focus user's resources on active projects.</p>
-
-                    <h5>Discussion</h5>
-                    <p><a href="https://cryptocurrencytalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">CCT Whitelist thread</a></p>
-                    <p><a href="https://cryptocurrencytalk.com/forum/2436-projects/">Projects subforum</a></p>
+                    <h5>Discussions</h5>
+                    <p><a href="https://web.archive.org/web/20150416222027/cryptocointalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">CCT Whitelist thread</a></p>
                 </div>
 
                 <div class="col-12 col-sm-8">
                     <h5>Please note:</h5>
                     <p>You will only be rewarded Gridcoin for whitelisted BOINC projects.</p>
                     <p>Any BOINC work done outside of the whitelisted BOINC projects will not be rewarded Gridcoin.</p>
-                    <p>Want a project whitelisted? <a href="https://cryptocurrencytalk.com/forum/2436-projects/">Create a thread about it</a>! More details about adding a project to the whitelist can be found on the <a href="/wiki/whitelist-process.html">whitelist process wiki page</a></p>
+                    <p>Want a project whitelisted? Ask about it on the <code>#whitelisting-committee</code> channel on the Gridcoin Discord! More details about adding a project to the whitelist can be found on the <a href="/wiki/whitelist-process.html">whitelist process wiki page</a></p>
                     <p>You can check whitelisted project details on <a href="https://gridcoinstats.eu/project">Gridcoinstats</a>.</p>
                     <p>The whitelist is verifiable on the wallet on the projects tab on the beacon menu or with the <code>listprojects</code> command</p>
                 </div>

--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -21,7 +21,7 @@ Durch die zur Verfügung gestellte Rechenzeit und den damit
 ausgeführten Berechnungen bietet Gridcoin einen Mehrwert. 
 Prinzipiell gibt es keine Einschränkungen, für welche BOINC Projekte Nutzer mit Gridcoins belohnt werden können. Gridcoin nutzt jedoch eine Whitelist und es lassen sich nur mit Projekten auf der Whitelist Gridcoins verdienen. Um ein Projekt auf die Whitelist zu bringen, kann eine dezentrale Abstimmung auf der Blockchain gestartet werden. Ist die Mehrheit der Nutzer dafür, so wird das Projekt in die Whitelist aufgenommen.
 
-Gridcoin wurde am 16. Oktober 2013 von einem anonymen Programmierer mit dem Pseudonym Rob Halförd gegründet, wie man einer Nachricht auf [CryptocurrencyTalk](https://cryptocurrencytalk.com/topic/1416-gridcoin-grc-information-classic-in-retirement/) entnehmen kann.
+Gridcoin wurde am 16. Oktober 2013 von einem anonymen Programmierer mit dem Pseudonym Rob Halförd gegründet, wie man einer Nachricht auf [CryptocurrencyTalk](https://web.archive.org/web/20150622170203/cryptocointalk.com/topic/1416-gridcoin-grc-information-classic-in-retirement/) entnehmen kann.
 
 Die Coin belohnt die "Miner" für ihren Beitrag in [BOINC](boinc "wikilink")
 Projekten für Medizin, Biologie, Mathematik, Klimaforschung, Partikel- oder Astrophysik.
@@ -161,8 +161,6 @@ energieeffizienter ist als der Proof of Work Algorithmus. Nutzer können zusätz
 <!-- end list -->
 
   - Foren:
-      - [Cryptocurrencytalk](https://cryptocurrencytalk.com/forum/464-gridcoin-grc/)
-      - [Cryptocurrencytalk macOS](https://cryptocurrencytalk.com/topic/13139-os-x-builds-feedback-bug-reporting/)
       - [Bitcointalk](https://bitcointalk.org/index.php?topic=324118.0)
       - [Steemit](https://steemit.com/created/gridcoin)
       - [Steemit Community](https://steemit.com/created/hive-161364)

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -386,9 +386,6 @@ The wallet has an automated backup in place that will make backups every 24 hour
 Different methods were discussed in the Gridcoin Community Classroom
 \#003: <https://www.youtube.com/watch?v=JxrjUwX5XvA>
 
-ref:
-<https://cryptocurrencytalk.com/topic/1331-new-coin-launch-announcement-grc-gridcoin/?view=findpost&p=158422>
-
 ---
 ### How to compress my wallet getting rid of orphans?
 

--- a/wiki/foundation.md
+++ b/wiki/foundation.md
@@ -45,4 +45,4 @@ future purpose and use of the foundation is up to the community to decide
 
 [^1]: Not referring to the actual artist. They used Rob Halförd as a username/pseudonym
 [^2]: See <https://steemit.com/gridcoin/@barton26/gridcoin-foundation-wallet-is-now-multi-sig>
-[^3]: See the old thread here <https://cryptocurrencytalk.com/topic/85404-developer-compensation-retired/>
+[^3]: See the old thread here <https://web.archive.org/web/20201109034508/https://cryptocurrencytalk.com/topic/85404-developer-compensation-retired/>

--- a/wiki/gridcoin-classic.md
+++ b/wiki/gridcoin-classic.md
@@ -64,6 +64,6 @@ development bounties, etc.
 
 The following CCT threads were used for discussion of disposition of the
 coins:
-* <https://cryptocurrencytalk.com/topic/26169-gridcoin-foundation-thread/>
-* <https://cryptocurrencytalk.com/topic/31314-discussion-leftover-burn-process-coins-what-should-be-their-fate/>
-* <https://cryptocurrencytalk.com/topic/37900-poll-disposition-of-coins-remaining-in-foundation/?mode=show>
+* <https://web.archive.org/web/20150417132330/https://cryptocointalk.com/topic/26169-gridcoin-foundation-thread//>
+* <https://web.archive.org/web/20150417040443/https://cryptocointalk.com/topic/31314-discussion-leftover-burn-process-coins-what-should-be-their-fate/>
+* <https://web.archive.org/web/20160119120234/https://cryptocointalk.com/topic/38199-foundation-block-coin-distribution-promotion-and-development-discussion/>

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -24,8 +24,8 @@ There are no limitations to a single BOINC project, providing the
 flexibility to be rewarded for virtually any type of computational
 process.
 
-Gridcoin was launched on October 16th, 2013 by Rob Halförd, following an
-announcement on [CryptocurrencyTalk](https://cryptocurrencytalk.com/topic/1416-gridcoin-grc-information-classic-in-retirement/).
+Gridcoin was launched on October 16th, 2013 by Rob Halförd, following [an
+announcement on CryptocurrencyTalk](https://web.archive.org/web/20150622170203/cryptocointalk.com/topic/1416-gridcoin-grc-information-classic-in-retirement/).
 
 The coin compensates the coin miners (researchers) for participating in
 [BOINC](boinc "wikilink") projects that may lead to advances in
@@ -171,8 +171,6 @@ scientific computations instead of securing the blockchain.
 <!-- end list -->
 
   - Forums:
-      - [Cryptocurrencytalk](https://cryptocurrencytalk.com/forum/464-gridcoin-grc/)
-      - [Cryptocurrencytalk macOS](https://cryptocurrencytalk.com/topic/13139-os-x-builds-feedback-bug-reporting/)
       - [Bitcointalk](https://bitcointalk.org/index.php?topic=324118.0)
       - [Steemit](https://steemit.com/created/gridcoin)
       - [Steemit Community](https://steemit.com/created/hive-161364)

--- a/wiki/staking.md
+++ b/wiki/staking.md
@@ -105,7 +105,7 @@ This goes into much further details of the statistics involved and more.
 The reward amounts currently used were chosen through a poll titled ["Constant Block Reward (cbr) Proposal And Poll"](http://main.gridcoinstats.eu/poll/22c2ee5e0c049ce93acc6f40d0430f6335367da1c3f61c66d211863cb346600d/1/ended:2). 
 The 75/25 option was chosen meaning a 75% to 25% split of new coins between crunchers and non-crunchers respectively.
 If you would like an in depth reading about the economics of it see either the 
-[reddit](https://www.reddit.com/r/gridcoin/comments/8bcrlz/constant_block_reward_cbr_value_proposal_and_poll/), [github](https://github.com/gridcoin-community/economics/issues/1), or [CCT](https://cryptocurrencytalk.com/topic/101374-constant-block-reward-cbr-value-proposal-and-poll/) thread. This went into
+[reddit](https://www.reddit.com/r/gridcoin/comments/8bcrlz/constant_block_reward_cbr_value_proposal_and_poll/), [github](https://github.com/gridcoin-community/economics/issues/1), or [steem](https://steemit.com/gridcoin/@jringo/constant-block-reward-cbr-value-proposal-and-poll) thread. This went into
 effect on version 4.0.0.0 after a hard fork (see [this reddit post for more information](https://www.reddit.com/r/gridcoin/comments/9pgg7m/gridcoin_mandatory_update_4000_released_cbr/) for details)
 
 ---


### PR DESCRIPTION
Their site has been broken for about a month now and keeps redirecting to google for every page.

* Removes references of it as a community site
* Replaces some links with archive.org links where needed and available