### PR TITLE
Links: Add Gridcoin.ch As Block Explorer

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -89,6 +89,9 @@
                     <!--<li>
                         <a href="https://grcexplorer.neuralminer.io">NeuralMiner.io</a>
                     </li>-->
+                    <li>
+                        <a href="https://gridcoin.ch/dashboard">Gridcoin.ch</a>
+                    </li>
                     <li role="presentation"><h6>Team Stats</h6></li>
                     <li>
                         <a href="https://boincstats.com/en/stats/-1/team/detail/118094994/projectList">Boincstats</a>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -80,15 +80,9 @@
                     <li>
                         <a href="https://www.gridcoinstats.eu/block">GridcoinStats</a>
                     </li>
-                    <!--<li>
-                        <a href="https://www.nuad.de/block-explorer/">Nuad.de</a>
-                    </li>-->
                     <li>
                         <a href="https://gridcoin.network/">Gridcoin.network</a>
                     </li>
-                    <!--<li>
-                        <a href="https://grcexplorer.neuralminer.io">NeuralMiner.io</a>
-                    </li>-->
                     <li>
                         <a href="https://gridcoin.ch/dashboard">Gridcoin.ch</a>
                     </li>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -109,6 +109,7 @@
                             <h6 class="dropdown-header text-center">Block Explorers</h6>
                             <a class="dropdown-item" href="https://www.gridcoinstats.eu/block">GridcoinStats</a>
                             <a class="dropdown-item" href="https://gridcoin.network/">Gridcoin.network</a>
+                            <a class="dropdown-item" href="https://gridcoin.ch/dashboard">Gridcoin.ch</a>
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">Team Stats</h6>
                             <a class="dropdown-item" href="https://boincstats.com/en/stats/-1/team/detail/118094994/projectList">Boincstats</a>

--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -115,6 +115,7 @@ energieeffizienter ist als der Proof of Work Algorithmus. Nutzer können zusätz
   - Block Explorer:
       - [Gridcoinstats](https://gridcoinstats.eu/)
       - [Gridcoin.network](https://gridcoin.network/)
+      - [Gridcoin.ch](https://gridcoin.ch/dashboard)
 
 <!-- end list -->
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -124,6 +124,7 @@ scientific computations instead of securing the blockchain.
   - Block Explorers:
       - [Gridcoinstats](https://gridcoinstats.eu/)
       - [Gridcoin.network](https://gridcoin.network/)
+      - [Gridcoin.ch](https://gridcoin.ch/dashboard)
 
 <!-- end list -->
 


### PR DESCRIPTION
* Adds Gridcoin.ch as a block explorer in the header and footer of the page as well as wiki links
* Remove some commented out dead links that have been offline for quite some time