### PR TITLE
Minor: Fix Link at Bottom of Gridcoin-Setup Page

### DIFF
--- a/guides/noncruncher-gridcoin-setup.htm
+++ b/guides/noncruncher-gridcoin-setup.htm
@@ -82,7 +82,7 @@ redirect_from:
             <div class="col-12 col-sm-12 col-md-4 col-lg-4">
                 <h5>Step 1</h5>
                 <hr />
-                <a href="/guides/noncrucher-gridcoin-setup.htm">
+                <a href="/guides/noncruncher-gridcoin-setup.htm">
                     <button class="btn btn-success" id="Guide-Button">
                     Setup Gridcoin Research Client
                     </button>


### PR DESCRIPTION
Correct a typo to make the link at the bottom of the Gridcoin-Setup page not give a 404. Is only a minor issue since this is linking to the page it's are already on. Checked for other typos of this link and didn't find any more 