### PR TITLE
Whitelist: Update WCG to Mention New GPU Work

### DIFF
--- a/_data/whitelist.yml
+++ b/_data/whitelist.yml
@@ -189,7 +189,7 @@ projects:
     materials for solar panels.
   sponsor: Sponsored by the IBM responsibility initiative
   cpu: 'yes'
-  gpu: 'no'
+  gpu: 'yes'
   gdpr: 'yes'
   gdpr-enable-steps: https://www.worldcommunitygrid.org/ms/viewDataSharing.action
   team: https://secure.worldcommunitygrid.org/team/viewTeamInfo.do?teamId=BBNGDQS832


### PR DESCRIPTION
Now that World Community Grid Has GPU work (see [here](https://www.worldcommunitygrid.org/about_us/viewNewsArticle.do?articleId=693)), we should update it on the whitelist page to reflect that