### PR TITLE
Replace all *.gridcoin.pl with seed.gridcoin.pl

### DIFF
--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -21,14 +21,16 @@ in the debug console.
 
 ## List Of Addnodes
 
-Tables with a list of addnodes, their domain name, and their region. See [cycy's hourly updating list](https://addnode.cycy.me)
-if you want another source of addnodes. The status on this wiki page is not updated frequently.
+Tables with a list of addnodes, their domain name, and their region. 
+
+The status on this wiki page is not updated frequently.
 
 
 ### Mainnet
 
-List of addnodes for the main network. This is the one you most likely care about
+List of addnodes for the main network. These are the ones you most likely care about.
 
+See [cycy's hourly updating list](https://addnode.cycy.me) for a more up to date status.
 ------------
 
 #### Default
@@ -79,6 +81,8 @@ These are included in the default config.
 
 List of addnodes for the [test network](testnet "wikilink")
 
+[cycy's hourly updating list](https://addnode.cycy.me/testnet)
+
 ------------
 
 #### Online (connected within the last 24 hours)
@@ -88,6 +92,7 @@ List of addnodes for the [test network](testnet "wikilink")
 | addnode-us-central.cycy.me | US-central |
 | ec2-3-81-39-58.compute-1.amazonaws.com  | US-east |
 | gridhost.ddns.net                       | UK |
+| ormgas.com                              | Sweden |
 | swe.tplinkdns.com                       | Sweden |
 | tarmoilves.eu                           | Estonia |
 
@@ -99,7 +104,6 @@ List of addnodes for the [test network](testnet "wikilink")
 | ---- | ------ |
 | gridcoin.ddns.net                       | UK |
 | gridcoin.network                        | France |
-| ormgas.com                              | Sweden |
 | test.grcpool.com                        | US-east |
 | testnet.dihelix.com                     | US |
 | vancouver01.gridcoin.ifoggz-network.xyz | Canada |

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -24,7 +24,7 @@ You shouldn't need to add them manually as a few are hardcoded into the wallet.
 ## List Of Addnodes
 
 Tables with a list of addnodes, their domain name, and their region. See [cycy's hourly updating list](https://addnode.cycy.me)
-if you want another source of addnodes. The status on this page is not updated frequently.
+if you want another source of addnodes. The status on this wiki page is not updated frequently.
 
 
 ### Mainnet

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -38,9 +38,9 @@ These are included in the default config.
 
 | Node | Region |
 |-|-|
-| addnode=addnode-us-central.cycy.me | US-central |
-| addnode=ec2-3-81-39-58.compute-1.amazonaws.com | US-east |
-| addnode=gridcoin.crypto.fans | Unknown |
+| addnode-us-central.cycy.me | US-central |
+| ec2-3-81-39-58.compute-1.amazonaws.com | US-east |
+| gridcoin.crypto.fans | Unknown |
 | gridcoin.ddns.net | UK |
 | london.grcnode.co.uk | UK |
 | seeds.gridcoin.ifoggz-network.xyz | Canada |

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -33,6 +33,21 @@ List of addnodes for the main network. This is the one you most likely care abou
 
 ------------
 
+#### Default
+These are included in the default config. 
+
+| Node | Region |
+|-|-|
+| addnode=addnode-us-central.cycy.me | US-central |
+| addnode=ec2-3-81-39-58.compute-1.amazonaws.com | US-east |
+| addnode=gridcoin.crypto.fans | Unknown |
+| gridcoin.ddns.net | UK |
+| london.grcnode.co.uk | UK |
+| seeds.gridcoin.ifoggz-network.xyz | Canada |
+| seed.gridcoin.pl | Europe |
+| www.grcpool.com | US-east |
+
+
 #### Online (connected within the last 24 hours)
 
 | Node | Region |
@@ -45,7 +60,6 @@ List of addnodes for the main network. This is the one you most likely care abou
 | swe.tplinkdns.com                       | Sweden |
 | tarmoilves.eu                           | Estonia |
 | vancouver01.gridcoin.ifoggz-network.xyz | Canada |
-| seed.gridcoin.pl                        | Europe |
 
 ------------
 
@@ -62,7 +76,6 @@ List of addnodes for the main network. This is the one you most likely care abou
 | node1.chick3nman.com                    | US-central |
 | nuad.de                                 | Germany |
 | seattle.grcnode.deluxe-host.net         | US-west |
-| vancouver01.gridcoin.ifoggz-network.xyz | Canada |
 
 ------------
 

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -15,6 +15,8 @@ will get more chances to find other nodes
 You can add these into your config file with `addnode=ADDNODE`. 
 See the [config file](config-file "wikilink") page about how to change your config
 
+**Make sure you have at least a few addnodes in your config or you won't be able to connect to the network.**
+
 You can also add the node with the command: `addnode <node> <add|remove|onetry>` 
 in the debug console.
 
@@ -31,6 +33,7 @@ The status on this wiki page is not updated frequently.
 List of addnodes for the main network. These are the ones you most likely care about.
 
 See [cycy's hourly updating list](https://addnode.cycy.me) for a more up to date status.
+
 ------------
 
 #### Default

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -21,7 +21,7 @@ in the debug console.
 
 ## List Of Addnodes
 
-Tables with a list of addnodes, their domain name, and their region. 
+Tables with a list of addnodes, and their region. 
 
 The status on this wiki page is not updated frequently.
 

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -37,19 +37,17 @@ List of addnodes for the main network. This is the one you most likely care abou
 | Node | Region |
 |----|-----|
 | addnode-us-central.cycy.me                 | US-central |
-| ch.gridcoin.pl                             | Switzerland|
 | ec2-3-81-39-58.compute-1.amazonaws.com     | US-east |
-| fi.gridcoin.pl                             | Finland |
 | grcnode.tahvok.com                         | Germany |
 | grcnode.thefoxie.eu                        | Germany |
 | gridcoin.network                           | France |
 | gridhost.ddns.net                          | UK |
 | node.gridcoin.network                      | France |
-| pl.gridcoin.pl                             | Poland |
 | seeds.gridcoin.ifoggz-network.xyz          | Canada |
 | swe.tplinkdns.com                          | Sweden |
 | tarmoilves.eu                              | Estonia |
 | vancouver01.gridcoin.ifoggz-network.xyz    | Canada |
+| seed.gridcoin.pl                           | Europe |
 
 ------------
 
@@ -74,9 +72,7 @@ List of addnodes for the main network. This is the one you most likely care abou
 
 | Node | Region |    
 | ---- | ------ |
-| by.gridcoin.pl                             | Belarus |
 | cloud.sparlin.me                           | Unknown |
-| de.gridcoin.pl                             | Germany |
 | grcexplorer.neuralminer.io                 | US |
 | grcmagnitude.com                           | Unknown |
 | grcnode.nems.space                         | US |
@@ -88,17 +84,12 @@ List of addnodes for the main network. This is the one you most likely care abou
 | gridcoin.crypto.fans                       | Germany |
 | gridcoin.univunix.com                      | Luxembourg |
 | ils.gridcoin.co.il                         | Canada |
-| is.gridcoin.pl                             | Iceland |
 | london.grcnode.co.uk                       | UK |
-| nl.gridcoin.pl                             | Netherlands |
-| no.gridcoin.pl                             | Norway |
 | node.gridcoin.us                           | US |
 | node.gridcoinapp.xyz                       | Germany |
 | quebec.gridcoin.co.il                      | Canada |
 | seattle.gridcoin.stablenode.net            | US-west |
 | toronto01.gridcoin.ifoggz-network.xyz      | Canada |
-| uk.gridcoin.pl                             | UK |
-
 ------------
 
 ### Testnet

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -87,7 +87,8 @@ List of addnodes for the [test network](testnet "wikilink")
 
 | Node | Region |
 | ---- | ------ |
-| gridcoin.ddns.net                       | UK |
+| addnode-us-central.cycy.me | US-central |
+| ec2-3-81-39-58.compute-1.amazonaws.com  | US-east |
 | gridhost.ddns.net                       | UK |
 | swe.tplinkdns.com                       | Sweden |
 | tarmoilves.eu                           | Estonia |
@@ -98,7 +99,9 @@ List of addnodes for the [test network](testnet "wikilink")
 
 | Node | Region |
 | ---- | ------ |
+| gridcoin.ddns.net                       | UK |
 | gridcoin.network                        | France |
 | ormgas.com                              | Sweden |
+| test.grcpool.com                        | US-east |
 | testnet.dihelix.com                     | US |
 | vancouver01.gridcoin.ifoggz-network.xyz | Canada |

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -18,8 +18,6 @@ See the [config file](config-file "wikilink") page about how to change your conf
 You can also add the node with the command: `addnode <node> <add|remove|onetry>` 
 in the debug console.
 
-You shouldn't need to add them manually as a few are hardcoded into the wallet.
-
 
 ## List Of Addnodes
 

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -18,12 +18,13 @@ See the [config file](config-file "wikilink") page about how to change your conf
 You can also add the node with the command: `addnode <node> <add|remove|onetry>` 
 in the debug console.
 
+You shouldn't need to add them manually as a few are hardcoded into the wallet.
 
 
 ## List Of Addnodes
 
 Tables with a list of addnodes, their domain name, and their region. See [cycy's hourly updating list](https://addnode.cycy.me)
-if you want another source of addnodes
+if you want another source of addnodes. The status on this page is not updated frequently.
 
 
 ### Mainnet
@@ -36,18 +37,15 @@ List of addnodes for the main network. This is the one you most likely care abou
 
 | Node | Region |
 |----|-----|
-| addnode-us-central.cycy.me                 | US-central |
-| ec2-3-81-39-58.compute-1.amazonaws.com     | US-east |
-| grcnode.tahvok.com                         | Germany |
-| grcnode.thefoxie.eu                        | Germany |
-| gridcoin.network                           | France |
-| gridhost.ddns.net                          | UK |
-| node.gridcoin.network                      | France |
-| seeds.gridcoin.ifoggz-network.xyz          | Canada |
-| swe.tplinkdns.com                          | Sweden |
-| tarmoilves.eu                              | Estonia |
-| vancouver01.gridcoin.ifoggz-network.xyz    | Canada |
-| seed.gridcoin.pl                           | Europe |
+| grcnode.tahvok.com                      | Germany |
+| grcnode.thefoxie.eu                     | Germany |
+| gridcoin.network                        | France |
+| gridhost.ddns.net                       | UK |
+| node.gridcoin.network                   | France |
+| swe.tplinkdns.com                       | Sweden |
+| tarmoilves.eu                           | Estonia |
+| vancouver01.gridcoin.ifoggz-network.xyz | Canada |
+| seed.gridcoin.pl                        | Europe |
 
 ------------
 
@@ -55,41 +53,17 @@ List of addnodes for the main network. This is the one you most likely care abou
 
 | Node | Region |    
 | ---- | ------ |
-| gridcoin.asia                              | Unknown |
-| gridcoin.bunnyfeet.fi                      | US-west |
-| gridcoin.certic.info                       | UK |
-| gridcoin.ddns.net                          | UK |
-| gridcoin.hopto.org                         | Germany |
-| gridcoins.org                              | UK |
-| node.grcpool.com                           | US-east |
-| node1.chick3nman.com                       | US-central |
-| nuad.de                                    | Germany |
-| seattle.grcnode.deluxe-host.net            | US-west |
+| grcmagnitude.com                        | Unknown |
+| gridcoin.asia                           | Unknown |
+| gridcoin.bunnyfeet.fi                   | US-west |
+| gridcoin.certic.info                    | UK |
+| gridcoin.hopto.org                      | Germany |
+| gridcoins.org                           | UK |
+| node1.chick3nman.com                    | US-central |
+| nuad.de                                 | Germany |
+| seattle.grcnode.deluxe-host.net         | US-west |
+| vancouver01.gridcoin.ifoggz-network.xyz | Canada |
 
-------------
-
-#### Dead (hostname resolution failed)
-
-| Node | Region |    
-| ---- | ------ |
-| cloud.sparlin.me                           | Unknown |
-| grcexplorer.neuralminer.io                 | US |
-| grcmagnitude.com                           | Unknown |
-| grcnode.nems.space                         | US |
-| grcnode01.neuralminer.io                   | US-central |
-| grcnode02.neuralminer.io                   | US-east |
-| grcnode03.neuralminer.io                   | Ireland |
-| grcnode04.neuralminer.io                   | Korea |
-| grcnode05.neuralminer.io                   | US-west |
-| gridcoin.crypto.fans                       | Germany |
-| gridcoin.univunix.com                      | Luxembourg |
-| ils.gridcoin.co.il                         | Canada |
-| london.grcnode.co.uk                       | UK |
-| node.gridcoin.us                           | US |
-| node.gridcoinapp.xyz                       | Germany |
-| quebec.gridcoin.co.il                      | Canada |
-| seattle.gridcoin.stablenode.net            | US-west |
-| toronto01.gridcoin.ifoggz-network.xyz      | Canada |
 ------------
 
 ### Testnet
@@ -102,12 +76,10 @@ List of addnodes for the [test network](testnet "wikilink")
 
 | Node | Region |
 | ---- | ------ |
-| addnode-us-central.cycy.me                 | US-central |
-| ec2-3-81-39-58.compute-1.amazonaws.com     | US-east |
-| gridcoin.ddns.net                          | UK |
-| gridhost.ddns.net                          | UK |
-| swe.tplinkdns.com                          | Sweden |
-| tarmoilves.eu                              | Estonia |
+| gridcoin.ddns.net                       | UK |
+| gridhost.ddns.net                       | UK |
+| swe.tplinkdns.com                       | Sweden |
+| tarmoilves.eu                           | Estonia |
 
 ------------
 
@@ -115,17 +87,7 @@ List of addnodes for the [test network](testnet "wikilink")
 
 | Node | Region |
 | ---- | ------ |
-| gridcoin.network                           | France |
-| ormgas.com                                 | Sweden |
-| test.grcpool.com                           | US-east |
-| testnet.dihelix.com                        | US |
-| vancouver01.gridcoin.ifoggz-network.xyz    | Canada |
-
-------------
-
-#### Dead (hostname resolution failed)      
-
-| Node | Region |
-| ---- | ------ |
-| testnet.grcnode.co.uk                      | Netherlands |
-| toronto01.gridcoin.ifoggz-network.xyz      | Canada |
+| gridcoin.network                        | France |
+| ormgas.com                              | Sweden |
+| testnet.dihelix.com                     | US |
+| vancouver01.gridcoin.ifoggz-network.xyz | Canada |

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -38,9 +38,7 @@ These are included in the default config.
 |-|-|
 | addnode-us-central.cycy.me | US-central |
 | ec2-3-81-39-58.compute-1.amazonaws.com | US-east |
-| gridcoin.crypto.fans | Unknown |
 | gridcoin.ddns.net | UK |
-| london.grcnode.co.uk | UK |
 | seeds.gridcoin.ifoggz-network.xyz | Canada |
 | seed.gridcoin.pl | Europe |
 | www.grcpool.com | US-east |

--- a/wiki/addnodes.md
+++ b/wiki/addnodes.md
@@ -37,7 +37,7 @@ See [cycy's hourly updating list](https://addnode.cycy.me) for a more up to date
 ------------
 
 #### Default
-These are included in the default config. 
+These are included in the default config, but if you leave them out of the config, it will not connect to these addnodes 
 
 | Node | Region |
 |-|-|


### PR DESCRIPTION
Requested by @wilkart, Closes gridcoin-community/Gridcoin-Wiki#6

DNS Load balancer for all of the replaced servers.

Additionally:
* Removed dead servers from list
* Update status from addnodes.cycy.me