### PR TITLE
Wiki: Clarify How Abstentions Are Excluded

### DIFF
--- a/wiki/voting.md
+++ b/wiki/voting.md
@@ -47,7 +47,7 @@ in each thread
 
 Each category has its own requirements which are listed in the [poll types](#poll-types "wikilink") section of this page 
 
-To pass, a poll must get a majority of the vote and must be at or above the poll's
+To pass, a poll must get a majority of the vote (excluding abstentions) and must be at or above the poll's
 active vote weight (AVW) requirement. AVW is an estimate how much voting
 weight is from users who are active on the network. It is described in more detail 
 in the [active vote weight](#active-vote-weight "wikilink") section


### PR DESCRIPTION
Adds a clarification about how abstentions are not counted in terms of a poll's yes/no ratio. Was something that was missed in #278

