### PR TITLE
Add SiDock@Home to Whitelist

### DIFF
--- a/_data/whitelist.yml
+++ b/_data/whitelist.yml
@@ -158,6 +158,16 @@ projects:
   team: http://srbase.my-firewall.org/sr5//team_display.php?teamid=99
   stats: https://gridcoinstats.eu/project/srbase
 
+- name: SiDock@Home
+  link: https://www.sidock.si/sidock/
+  goal: Works on drug discovery with COVID-19 as its primary focus
+  sponsor: COVID.SI project
+  cpu: 'yes'
+  gpu: 'no'
+  gdpr: 'no'
+  team: https://www.sidock.si/sidock/team_display.php?teamid=54
+  stats: https://www.gridcoinstats.eu/project/sidock@home
+
 - name: TN-Grid
   link: https://gene.disi.unitn.it/test/
   goal: 'The gene@home project is an implementation of the PC-IM algorithm, whose


### PR DESCRIPTION
Since the poll has now passed & been validated, SIDock@Home is now on the whitelist!

Note that the Gridcoinstats,eu stats URL doesn't work yet, but putting in by looking at how the names for other project have been put in place in the pas (i.e all lowercase and with the @ in the URL). Can update if needed, but I think that link is not as important as having the project listed on the site