### PR TITLE
Wiki: Fix Discord Links 

### DIFF
--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -168,7 +168,7 @@ energieeffizienter ist als der Proof of Work Algorithmus. Nutzer können zusätz
       - [Reddit](https://reddit.com/r/gridcoin)
       - [Reddit (ru)](https://reddit.com/r/russiangridcoin)
       - [Gridcoin Telegram](https://t.me/gridcoin)
-      - [Discord](https://discord.me/page/gridcoin)
+      - [Discord](https://discord.gg/jf9XX4a)
       - [Slack](https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/)
       - IRC: [#gridcoin](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin) and [#gridcoin-help](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin-help) on freenode.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -178,7 +178,7 @@ scientific computations instead of securing the blockchain.
       - [Reddit](https://reddit.com/r/gridcoin)
       - [Reddit (ru)](https://reddit.com/r/russiangridcoin)
       - [Gridcoin Telegram](https://t.me/gridcoin)
-      - [Discord](https://discord.me/page/gridcoin)
+      - [Discord](https://discord.gg/jf9XX4a)
       - [Slack](https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/)
       - IRC: [#gridcoin](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin) and [#gridcoin-help](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin-help) on freenode.
 

--- a/wiki/sv/index.md
+++ b/wiki/sv/index.md
@@ -172,7 +172,7 @@ beräkningar istället för att säkerställa blockkedjan.
       - [Reddit](https://reddit.com/r/gridcoin)
       - [Reddit (ru)](https://reddit.com/r/russiangridcoin)
       - [Gridcoin Telegram](https://t.me/gridcoin)
-      - [Discord](https://discord.me/page/gridcoin)
+      - [Discord](https://discord.gg/jf9XX4a)
       - [Slack](https://join.slack.com/t/teamgridcoin/shared_invite/enQtMjk2NTI4MzAwMzg0LTUzMmY0YjdiNzYxYzQ0MDc3MGE1NjQ3Nzg2NWMzZTUzMjAwZjdhMWI1YWUzMDE4YzQyZjVjMjMzOTc1M2RmMmM/)
       - IRC: [#gridcoin](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin) and [#gridcoin-help](https://kiwiirc.com/client/irc.freenode.net:6697/#gridcoin-help) on freenode.
 


### PR DESCRIPTION
Wiki home pages in all languages used a broken discord.me link for some reason. Switched them to use the same link that's in the header and footer