### PR TITLE
Wiki: Fix 2003 Being Interpreted as Numbering

### DIFF
--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -35,8 +35,8 @@ reward research. Gridcoin compares participants in each project by their
 subsidiary credits earned in BOINC to measure performance in relation to
 dynamic inner project network average.
 
-BOINC has been rewarding scientific work units in a credit system since
-2003. In case a project maintainer maliciously decides to give out more
+BOINC has been rewarding scientific work units in a credit system since 2003. 
+In case a project maintainer maliciously decides to give out more
 credits than appropriate, it only affects the inner project competition.
 The maximum share of new Gridcoins for this project stays the same
 percentage (subject to the number of total projects). And projects can be


### PR DESCRIPTION
Moved the text to the end of the line where it won't be interpreted as a numbering (only works at start of a line). I think that this is the simplest to read fix to this

**New:**
![image](https://user-images.githubusercontent.com/30132912/125623237-cd5c31d0-98bb-423c-a84d-cb490f38f7ce.png)


**Old:**
![image](https://user-images.githubusercontent.com/30132912/125623171-3b0eec26-b0ae-4523-8ab1-57448be85349.png)
