### PR TITLE
Wiki: Create Table of Contents Dropdown

### DIFF
--- a/_includes/_wiki_toc.md
+++ b/_includes/_wiki_toc.md
@@ -1,0 +1,21 @@
+{% comment %}
+This is a work around to use kramdown's table of contents generator, but
+on a side bar. High level: renders the full Markdown with the toc and 
+take out just the list
+
+Take the page data, replace the front matter with a comment so no false
+positive headers from that, convert the markdown to HTML, and then split 
+by the "markdown-toc-divider" text as a divider for the table. Remove the
+extra paragraph tags around the divider text
+{% endcomment %}
+{% capture page_data %}
+{% include_relative {{include.page}} %}
+
+markdown-toc-divider
+* replace
+{:toc}
+markdown-toc-divider
+
+{% endcapture %}
+{%- assign data = page_data | replace_first: "---", "<!--" | replace_first: "---", "-->" | markdownify | split: "markdown-toc-divider" -%}
+{{ data[1] | remove: "<p>" | remove: "</p>" }}

--- a/_layouts/wiki-de.html
+++ b/_layouts/wiki-de.html
@@ -23,6 +23,13 @@
                 <div class="col-xl-6" id="main" role="main">
                     {{ content  }}
                 </div>
+                <div class="col-xl-3">
+                    <details class="docs-toc">
+                        <summary>Inhaltsverzeichnis (zum Anzeigen klicken)</summary>
+                        {% assign cur_page = page.path | split: "/" | last%}
+                        {% include _wiki_toc.md page=cur_page %}
+                    </details>
+                </div>
             </div>
         </div>
         {% include _footer.htm %}

--- a/_layouts/wiki-sv.html
+++ b/_layouts/wiki-sv.html
@@ -23,6 +23,13 @@
                 <div class="col-xl-6" id="main" role="main">
                     {{ content  }}
                 </div>
+                <div class="col-xl-3">
+                    <details class="docs-toc">
+                        <summary>innehåll (klicka för att visa)</summary>
+                        {% assign cur_page = page.path | split: "/" | last%}
+                        {% include _wiki_toc.md page=cur_page %}
+                    </details>
+                </div>
             </div>
         </div>
         {% include _footer.htm %}

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -23,6 +23,13 @@
                 <div class="col-xl-6" id="main" role="main">
                     {{ content  }}
                 </div>
+                <div class="col-xl-3">
+                    <details class="docs-toc">
+                        <summary>Table of Contents (click to view)</summary>
+                        {% assign cur_page = page.path | split: "/" | last%}
+                        {% include _wiki_toc.md page=cur_page %}
+                    </details>
+                </div>
             </div>
         </div>
         {% include _footer.htm %}

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -419,10 +419,15 @@ dfn{
 .docs-container a[title="sitelink"]::after,
 .docs-container .footnote::after,
 .docs-container .reversefootnote::after,
+.docs-toc a::after,
 .docs-menu a::after{
     width:0px;
     height: 0px;
     margin:0px;
+}
+.docs-toc {
+    background-color: #343434;
+    border: dotted;
 }
 
 .cookies-eu-banner {


### PR DESCRIPTION
Creates a table of contents dropdown for each wiki page that shows all the headers and subheaders. Collapsed by default

<details>
<summary>Screenshots</summary>

(collapsed default view)
![image](https://user-images.githubusercontent.com/30132912/126080099-66335f8e-6c06-4f56-aaa6-59de6380a0b4.png)

(expanded view)
![image](https://user-images.githubusercontent.com/30132912/126080110-de7aa068-b4ff-477c-abf3-21075d966669.png)



</details>

Translations for the dropdown were done by Nussi for the German wiki and sweede-se for the Swedish wiki

Hosted this on my fork at: 
https://roboticmind.github.io/wiki/
https://roboticmind.github.io/wiki/de
https://roboticmind.github.io/wiki/sv