### PR TITLE
Fix typo link in Superblock doc and add link in the Scraper doc

### DIFF
--- a/wiki/scraper.md
+++ b/wiki/scraper.md
@@ -5,7 +5,7 @@ redirect_from:
   - "/Wiki/Scraper"
 ---
 
-The Scraper as described below meets or exceeds the definition of a blockchain Oracle and as such the Scraper system is being renamed the Gridcoin Oracle. See https://medium.com/fabric-ventures/decentralised-oracles-a-comprehensive-overview-d3168b9a8841 and https://cryptobriefing.com/what-is-blockchain-oracle/.
+The Scraper as described below meets or exceeds the definition of a blockchain Oracle and as such the Scraper system is being renamed the Gridcoin Oracle. See <https://medium.com/fabric-ventures/decentralised-oracles-a-comprehensive-overview-d3168b9a8841> and <https://cryptobriefing.com/what-is-blockchain-oracle/>.
 
 The previous .NET Visual Basic based distributed computing statistics gathering system, referred to as the Gridcoin “Neural Network,” was not really a neural network. It was actually a rules based system for gathering 3rd party distributed computing statistics (currently from BOINC projects) off blockchain, summarizing and normalizing them, and then providing a mechanism for the nodes in the network to agree on the statistics and put them on the blockchain in summarized form once a day. (This is referred to as a superblock.) The research rewards are then calculated and generated for/by staking wallets that perform research via the distributed computing platform BOINC, confirmed by other nodes in accordance with blockchain protocols (referred to as Proof-of-Research).
 

--- a/wiki/superblock.md
+++ b/wiki/superblock.md
@@ -19,7 +19,7 @@ Note that it doesn't really change anything for you as a staker other than just 
 # How Superblocks Get Made 
 
 1. A previous superblock is made and a 24 hour clock starts for the next superblock to be due[^1]
-2. Stats are independently gathered by the [scrapers](scrapers "wikilink") from the BOINC projects
+2. Stats are independently gathered by the [scrapers](scraper "wikilink") from the BOINC projects
 3. Those stats are sent out to each wallet which compare them and check that they match. 
 If at least 60% (rounded up) of the scrapers exactly match[^2], a superblock can be made (when it's due)
 4. Someone stakes and they include the new data from the scrapers


### PR DESCRIPTION
While I'm reading the Superblock wiki, I tried to click the scrapers link, which is currently 404 not found. This PR fixes the typo link from `scrapers` to `scraper`

Also, I found that the 1st paragraph of the Scraper wiki can be improved by adding links so it's clickable 😉 