### PR TITLE
Create Team and Contributors Page

### DIFF
--- a/_includes/_create_card.htm
+++ b/_includes/_create_card.htm
@@ -1,0 +1,9 @@
+<div class="col-sm-4 col-6 d-flex pb-3">
+    <div class="card bg-light text-dark">
+        <img class="card-img-top" src="{{ include.src }}" alt=" {{ include.alt_text }}">
+        <div class="card-body">
+            <p class="card-title h5"> {{ include.title }} </p>
+            <p class="card-text">{{ include.text }}</p>
+        </div>
+    </div>
+</div>

--- a/_includes/_end_row.htm
+++ b/_includes/_end_row.htm
@@ -1,0 +1,4 @@
+</div>
+{% comment %}
+Close the div tag opened in _start_row.htm
+{% endcomment %}

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -62,7 +62,7 @@
                         <a href="https://github.com/gridcoin-community/Gridcoin-Research">Github</a>
                     </li>
                     <li>
-                        <a href="https://github.com/gridcoin-community/Gridcoin-Research/graphs/contributors">Core Wallet Contributors</a>
+                        <a href="/wiki/team-and-contributors.html">Team & Contributors</a>
                     </li>
                     <li>
                         <a href="/wiki/rpc.html">RPC Wiki Page</a>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -53,7 +53,7 @@
                             <div class="dropdown-divider"></div>
                             <h6 class="dropdown-header text-center">Development</h6>
                             <a class="dropdown-item" href="https://github.com/gridcoin-community">Github Repositories</a>
-                            <a class="dropdown-item" href="https://github.com/gridcoin-community/Gridcoin-Research/graphs/contributors">Core Wallet Contributors</a>
+                            <a class="dropdown-item" href="/wiki/team-and-contributors.html">Team & Contributors</a>
                             <a class="dropdown-item" href="/wiki/rpc.html">RPC Wiki Page</a>
                             <a class="dropdown-item" href="/#Downloads">Wallet Downloads</a>
                             <a class="dropdown-item" href="https://snapshot.gridcoin.us/snapshot.zip">Official Snapshot</a>

--- a/_includes/_start_row.htm
+++ b/_includes/_start_row.htm
@@ -1,0 +1,4 @@
+<div class="row">
+{% comment %}
+Create a row with bootstrap
+{% endcomment %}

--- a/wiki/team-and-contributors.md
+++ b/wiki/team-and-contributors.md
@@ -1,0 +1,204 @@
+---
+title: Team and Contributors
+layout: wiki
+description: List of people and users involved in the development of Gridcoin
+---
+
+# Team and Contributors
+
+## Core Developers 
+
+*The main developers of the Gridcoin wallet*
+
+{% include _start_row.htm %}
+
+{% include _create_card.htm
+src="https://github.com/jamescowens.png"
+alt_text="Image of James Owens"
+title="James C Owens"
+text="Lead Core Developer"
+%}
+
+{% include _create_card.htm
+src="https://github.com/denravonska.png"
+alt_text="Image of Marco Nilsson"
+title="Marco Nilsson"
+text="Core Developer"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/cyrossignol.png"
+alt_text="Image of Cy Rossignol"
+title="Cy Rossignol (cycy)"
+text="Core Developer"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/iFoggz.png"
+alt_text="Avatar of iFoggz"
+title="Paul Jensen (iFoggz)"
+text="Core Developer"
+%}
+
+{% include _create_card.htm
+src="https://github.com/div72.png"
+alt_text="Avatar of div72"
+title="div72"
+text="Core Developer"
+%}
+
+
+{% include _end_row.htm %}
+
+## Website Developers
+*The developers and maintainers of the gridcoin.us website*
+
+{% include _start_row.htm %}
+
+{% include _create_card.htm
+src="https://github.com/roboticmind.png"
+alt_text="Avatar of Roboticmind"
+title="Roboticmind"
+text="Gridcoin.us and Wiki Developer"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/barton2526.png"
+alt_text="Avatar of Barton26"
+title="Barton26"
+text="Gridcoin.us Maintainer & Community Moderator"
+%}
+
+{% include _create_card.htm
+src="https://github.com/ShmoogleOsukami.png"
+alt_text="Image of Ben Swinburn"
+title="Ben Swinburn (ShmoogleOsukami)"
+text="Gridcoin.us Maintainer"
+%}
+
+{% include _end_row.htm %}
+
+
+## Other Roles in the Community
+{% include _start_row.htm %}
+
+{% include _create_card.htm
+src="https://github.com/NeuralMiner.png"
+alt_text="Image of NeuralMiner"
+title="NeuralMiner"
+text="Community Moderator"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/jring-o.png"
+alt_text="Avatar of jringo"
+title="jringo"
+text="Community Engagement & Education"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/Pythonix.png"
+alt_text="Avatar of Pythonix"
+title="Pythonix"
+text="Twitter Manager"
+%}
+
+{% include _end_row.htm %}
+
+## Related Platforms/Tool Developers
+{% include _start_row.htm %}
+
+
+{% include _create_card.htm
+src="https://github.com/delta1512.png"
+alt_text="Avatar of delta"
+title="Delta"
+text="Discord Wallet Bot Maintainer & Community Engagement"
+%}
+
+{% include _create_card.htm
+src="https://github.com/startailcoon.png"
+alt_text="Avatar of Startail"
+title="Startail"
+text="Gridcoinstats.eu Developer"
+%}
+
+
+{% include _create_card.htm
+src="https://github.com/sau412.png"
+alt_text="Avatar of Tsarev Vladimir "
+title=" Tsarev Vladimir (sau412)"
+text="Gridcoinpool.ru Developer"
+%}
+
+{% include _create_card.htm
+src="https://github.com/bryhardt.png"
+alt_text="Avatar of bryhardt "
+title="bryhardt (bgb)"
+text="Grcpool Developer"
+%}
+
+{% include _end_row.htm %}
+
+
+## Package Managers
+{% include _start_row.htm %}
+
+{% include _create_card.htm
+src="https://github.com/caraka.png"
+alt_text="Image of Richard Leckinger"
+title="Richard Leckinger (caraka)"
+text="Debian/Ubuntu Package Manager"
+%}
+
+{% include _create_card.htm
+src="https://github.com/Tahvok.png"
+alt_text="Image of Albert Mikaelyan"
+title="Albert Mikaelyan (Tahvok)"
+text="Arch Package Manager"
+%}
+
+{% include _create_card.htm
+src="https://github.com/theMarix.png"
+alt_text="Image of Matthias Bach"
+title="Matthias Bach (theMarix)"
+text="openSUSE Package Manager"
+%}
+
+{% include _create_card.htm
+src="https://github.com/kingbeowulf.png"
+alt_text="Avatar of kingbeowulf"
+title="kingbeowulf"
+text="Slackware Package Manager"
+%}
+
+{% include _create_card.htm
+src="https://github.com/tunisiano.png"
+alt_text="Avatar of tunisiano"
+title="tunisiano"
+text="Chocolatey Package Manager"
+%}
+
+{% include _create_card.htm
+src="https://github.com/git-jiro.png"
+alt_text="Avatar of Martin Schimandl"
+title=" Martin Schimandl (git-giro)"
+text="MacOS Package Manager"
+%}
+
+{% include _end_row.htm %}
+
+
+
+## Other Contributors
+Many contributors of past and present can be found on the contributor tab of the [Gridcoin-Research repository](https://github.com/gridcoin-community/Gridcoin-Research/graphs/contributors),
+the [Gridcoin-Site repository](https://github.com/gridcoin-community/Gridcoin-Site/graphs/contributors), and
+other repositories under [@gridcoin-community](https://github.com/gridcoin-community/).
+
+Countless others work on Gridcoin from community building, translations,
+tools, and more


### PR DESCRIPTION
Creates a team and contributor page organized by role. Each user listed has a card with their GitHub profile picture and a brief description of their role . 


Can look at it running on my fork at https://roboticmind.github.io/wiki/team-and-contributors.html 