### PR TITLE
Wiki, Minor: Fix Capitzliation Issues and Update TODOs

### DIFF
--- a/wiki/advantages-and-features.md
+++ b/wiki/advantages-and-features.md
@@ -29,7 +29,7 @@ minimizes that amount of centralization. Scrapers get BOINC statistics
 the useful stats --- reducing data sent and stored. The wallet compares the 
 data from each scraper against each other limiting the trust needed. Scrapers are 
 run by several trusted members of the community located around the world. 
-Read more about scrapers on the [Scraper Wiki Page](Scraper "wikilink")
+Read more about scrapers on the [Scraper Wiki Page](scraper "wikilink")
 
 Further, Gridcoin has a [voting system](voting "wikilink") to help keep Gridcoin aligned with the
 community and have meaningful discussions. Voting helps reduce conflicts by

--- a/wiki/de/index.md
+++ b/wiki/de/index.md
@@ -101,7 +101,7 @@ Gridcoin Research basiert auf dem Proof of Stake Algorithmus, der deutlich
 energieeffizienter ist als der Proof of Work Algorithmus. Nutzer können zusätzlich Gridcoins verdienen, wenn sie mit ihrer Rechenleistung BOINC Projekte unterstützen.
 
 ## Offizielle Seiten
-  <!-- TODO: [Volunteers, Roles & Privileges](Volunteers,-Roles,-&-Privileges "wikilink") -->
+  <!-- TODO: team and contributors -->
   - [Website](https://gridcoin.us/)
   - [BOINCstats](https://boincstats.com/en/stats/-1/team/detail/118094994/overview)
   - [Netsoft](http://www.boinc.netsoft-online.com/e107_plugins/boinc/bp_home.php)

--- a/wiki/de/konfigurationsdatei.md
+++ b/wiki/de/konfigurationsdatei.md
@@ -42,7 +42,7 @@ Verhalten. Siehe [Testnet](testnet "wikilink") für weitere Informationen.
     ############ Erforderliche Einstellungen (Alle Betriebssysteme) #############
     #############################################################################
 
-    ## Von der Community bereitgestellte Liste verfügbare Addnodes [Addnodes](Addnodes "wikilink")
+    ## Von der Community bereitgestellte Liste verfügbare Addnodes [Addnodes](addnodes "wikilink")
     #~~~~~Addnodes kopieren und hier einfügen~~~~~
 
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -109,7 +109,7 @@ Proof-of-Stake allows miners to dedicate their compute resources towards
 scientific computations instead of securing the blockchain.
 
 ## Official Resources
-  <!-- TODO: [Volunteers, Roles & Privileges](Volunteers,-Roles,-&-Privileges "wikilink") -->
+  - [Team and Contributors](team-and-contributors "wikilink")
   - [Other Wiki Pages](pages "wikilink")
   - [Website](https://gridcoin.us/)
   - [BOINCstats](https://boincstats.com/en/stats/-1/team/detail/118094994/overview)

--- a/wiki/sv/index.md
+++ b/wiki/sv/index.md
@@ -103,7 +103,7 @@ Proof-of-Stake låter användarna använda sin datorkraft till vetenskapliga
 beräkningar istället för att säkerställa blockkedjan.
 
 ## Officiella Resurser
-  <!-- TODO: [Volunteers, Roles & Privileges](Volunteers,-Roles,-&-Privileges "wikilink") -->
+  <!-- TODO: team and contributors -->
   - [Andra wikisidor](pages "wikilink")
   - [Hemsida](https://gridcoin.us/)
   - [BOINCstats](https://boincstats.com/en/stats/-1/team/detail/118094994/overview)


### PR DESCRIPTION
* Fixes two wiki links that are incorrectly capitalized
* Update the home wiki page TODOs about a `Volunteers,-Roles,-&-Privileges` page  
  * For the en wiki use the new `team-and-contributors` page
  * For the other languages, update the TODO comment to match the new page name