### PR TITLE
Wiki: Scraper Page Update, New Beacon Page, and Remove More Mentions of the Team Requirement

### DIFF
--- a/wiki/beacons.md
+++ b/wiki/beacons.md
@@ -1,0 +1,38 @@
+---
+title: Beacons 
+description: Overview of BOINC and how it relates to Gridcoin
+layout: wiki
+---
+
+# Overview
+
+Beacons are what tie a user to their work on BOINC. They are only required
+for solo crunching and have a fee of 0.5 GRC + transaction fees. To keep a beacon
+active, it must be renewed every 6 months
+
+See [the last step](/guides/earn-grc.htm "sitelink") of the solo crunching guide 
+for the process of sending a beacon. Note that BOINC and the Gridcoin wallet
+must be setup beforehand
+
+# Rational
+
+Beacons require verification to ensure a user is not trying to steal someone 
+else's reward. Additionally, they let the network know which BOINC user's stats
+to monitor and which to ignore.
+
+# What is in a Beacon?
+
+The beacon stores your BOINC Cross Project Identifier (CPID) and a cryptographic public
+key. The seemingly random text you use  for verification is a signed message 
+with your private key --- letting you prove you own that account 
+
+# Miscellaneous
+
+* The "beacon address" is just the address that you used to get the coins for your
+  beacon. There isn't anything special about the address otherwise, and it's just an
+  ordinary address
+
+* A beacon is technically a form of a smart contract albeit a simple one
+
+* You can view the status of your beacon (if you have one) on the researcher wizard 
+  or with the `beaconstatus` command

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -256,7 +256,7 @@ high magnitude to possibly run into this.
 # BOINC
 
 ---
-### Choosing BOINC projects: In BOINC, is there still a defined whitelist of "projects" or can we use any project now that has Gridcoin as a Team Name?
+### Choosing BOINC projects: In BOINC, is there still a defined whitelist of "projects" or can we use any project?
 
 Running "projects" in the console will list all the whitelisted
 projects you could possibly contribute to that would help your Gridcoin
@@ -268,11 +268,8 @@ wallet.
 
 That means you aren't participating in those projects or the e-mail
 address you have in the conf file doesn't match the e-mail address used
-in your BOINC manager on that machine. For every project you join, you
-also have to join the Gridcoin team on that project. Any changes about
-e-mail address on a project or team membership on a project take around
-a day to
-propagate.
+in your BOINC manager on that machine. Any changes about e-mail address on a
+project take around a day to propagate.
 
 ---
 ### I use BOINC with one username but on a few machines - is it enough to have one wallet with the proper boinc\_project\_email address, or do I have to have a separate wallet on each machine?
@@ -304,9 +301,6 @@ on every project you still have valid RAC on; so GRC does not support
 detaching projects (it was supposed to prevent gaming the system). There
 is no difference if you score 0 on a project, as all are taken into
 account equally.
-
-If you insist on not being paid for a specific project, change your team
-away from a recognised team for that project.
 
 ---
 # Status


### PR DESCRIPTION
* Updates the scraper page which was previously written before the scraper system went into place
* Creates a short page about beacons
* Remove more mentions of the team requirement (since I seem to keep missing some no matter which search terms I use...) 