### PR TITLE
Use checkout v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This fixes intermittent CI failures because node 12 is deprecated.