### PR TITLE
Add explicit width and height to blocks banner to fix CLS

### DIFF
--- a/_layouts/layout.htm
+++ b/_layouts/layout.htm
@@ -2,13 +2,13 @@
 <html class="h-100" lang="en">
     {% include _head.htm %}
     <body>
+        <script src="/assets/js/core/bootstrap-5.1.3.bundle.min.js" type="text/javascript" async></script>
         {% include _cookie_banner.htm %}
         {% include _header.htm %}
         <div class="min-h-80" id="main" role="main">{{ content }}</div>
         {% include _footer.htm %}
 
         <!--   Core JS Files   -->
-        <script src="/assets/js/core/bootstrap-5.1.3.bundle.min.js" type="text/javascript"></script>
         <script src="/assets/js/fetch-release.js" type="text/javascript"></script>
     </body>
 </html>

--- a/index.htm
+++ b/index.htm
@@ -7,7 +7,7 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-sm-10 w-xs-100 text-center">
-                <img class="img-fluid" src="/assets/img/gridcoinblocks-header.svg" alt="Gridcoin logo with coloured blocks behind it. Gridcoin is written in large, bold characters below the image.">
+                <img class="img-fluid" src="/assets/img/gridcoinblocks-header.svg" alt="Gridcoin logo with coloured blocks behind it. Gridcoin is written in large, bold characters below the image." width="1910" height="940">
                 <h1 class="h2 pt-3 fw-bold">Rewarding Volunteer Distributed Computing</h1>
             </div>
         </div>


### PR DESCRIPTION
Currently gridcoin.us can occasionally fail pagespeed tests due to excessive cumulative layout shift from the banner image not being loaded in time.

We are already using the img-fluid bootstrap class, which uses css to change the dimensions of the image in the viewport, so adding explicit widths and heights to the image should not affect how it renders under modern browsers [(Chrome, Safari and Firefox - according to Google)](https://web.dev/optimize-cls/?utm_source=lighthouse&utm_medium=lr#images-without-dimensions).