### PR TITLE
Replace "Rewarding Volunteer Distributed Computing" with "The Cryptocurrency of Science"

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -8,7 +8,7 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
         <div class="row justify-content-center">
             <div class="col-sm-10 w-xs-100 text-center">
                 <img class="img-fluid" src="/assets/img/gridcoinblocks-header.svg" alt="Gridcoin logo with coloured blocks behind it. Gridcoin is written in large, bold characters below the image.">
-                <h1 class="h2 pt-3 fw-bold">Rewarding Volunteer Distributed Computing</h1>
+                <h1 class="h2 pt-3 fw-bold">The Cryptocurrency of Science</h1>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I propose changing the title text of the main page from "Rewarding Volunteer Distibuted Computing" with "The Cryptocurrency of Science". My rationale is as follows:

- We should have our branding be clear and make a concise, easy-to-understand pitch to the visiting user. Our main pitch is that we are a cryptocurrency that supports science. "The Cryptocurrency of Science" says this quite concisely.
- "Rewarding Volunteer Distributed Computing" is a mouthful and uses scary technical language that will not seem accessible to average computer users. Even users experienced with cryptocurrency mining may not know what "volunteer computing" or "distributed computing" is. 
- A user who is interested in Gridcoin merely as a cryptocurrency and has no interest in crunching probably doesn't need to know what distributed/volunteer computing is. They just need to know that Gridcoin is a cryptocurrency which supports science, and that by using Gridcoin, they can support scientific research. They are going to be more interested in takeaway headlines like "Gridcoin crunchers find new cancer drugs" than "Gridcoin is a network of distributed computers connecting users to a wide variety of projects in a shared database blah blah blah"
- This change matches the branding found on the Gridcoin subreddit
- Further on down the page, we again mention rewarding volunteer distributed computing, so this change does not remove it entirely
- I have put this idea in the #future-development channel on discord and the limited response I have received indicates people support it. People have also generally supported making the language more accessible and less technically focused. Let's leave the technical language in areas specific to crunching.
