### PR TITLE
Remove references to snapshot from footer and solo crunching guide

### DIFF
--- a/_includes/_acquire.htm
+++ b/_includes/_acquire.htm
@@ -16,14 +16,6 @@
                         Before your wallet can do anything, it needs to be synced. The cloud icon at the bottom right of the wallet shows your sync status, you can hover the mouse over it for detailed information. A green cloud means it is fully synced. Note that the first time you run the wallet, it may take several hours to fully sync depending on your computer and internet connection speed.
                     </li>
                     <li>
-                        If you don't want to sync from 0, then you can download a snapshot of the blockchain from clicking File -> Snapshot Download or using the <code>-snapshotdownload</code> command line argument
-                        <ul>
-                            <li>
-                                The snapshot will only bring you up to 80-90% sync. Allow it to continue syncing after the snapshot has been extracted.
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
                         If you are unable to acquire connections to the Gridcoin network, attempt the following:
                         <ul>
                             <li>

--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -73,9 +73,6 @@
                     <li>
                         <a href="/#Downloads">Wallet Downloads</a>
                     </li>
-                    <li>
-                        <a href="https://snapshot.gridcoin.us/snapshot.zip">Official Snapshot</a>
-                    </li>
                     <li role="presentation"><h6>Block Explorers</h6></li>
                     <li>
                         <a href="https://www.gridcoinstats.eu/block">GridcoinStats</a>


### PR DESCRIPTION
Snapshots are being disabled and don't work at this point due to the snapshot hosting site being down. 
![image](https://github.com/gridcoin-community/Gridcoin-Site/assets/90811423/7ba3407c-c3d5-4802-8a01-574b85f5980c)
