### PR TITLE
Remove SafeTrade

### DIFF
--- a/_data/exchanges.yml
+++ b/_data/exchanges.yml
@@ -3,11 +3,7 @@ centralized-exchanges:
   - name: SouthXchange
     image: /assets/img/exchanges/southxchange.png
     link: https://www.southxchange.com/Market/Book/GRC/BTC
-  
-  - name: SafeTrade
-    image: /assets/img/exchanges/safetrade.png
-    link: https://safe.trade/trading/grcbtc
-  
+    
   - name: Flyp.me
     image: /assets/img/exchanges/flypme.png
     link: https://flyp.me/


### PR DESCRIPTION
The website has been down for several days already according to a user on Discord. We can add it back once it is online again.