### PR TITLE
Bump Ruby to 3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Ruby 3.0
+      - name: Set up Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
 
       - name: Install Bundle Dependencies 
         run: bundle install


### PR DESCRIPTION
Ruby 3.0 goes EOL in March. This will give us until 2025.

Tested and I see no changes on my branch.