### PR TITLE
Remove references to boincappdir

### DIFF
--- a/guides/gridcoin-install.htm
+++ b/guides/gridcoin-install.htm
@@ -90,11 +90,6 @@ redirect_from:
                                         boincdatadir=D:\\ProgramData\\BOINC\\
                                     </code>
                                 </li>
-                                <li>
-                                    <code>
-                                         boincappdir=C:\\Program Files\\BOINC\\
-                                    </code>
-                                </li>
                             </ul>
                         </li>
                         <li>

--- a/wiki/testnet.md
+++ b/wiki/testnet.md
@@ -143,7 +143,6 @@ to do, feel free to ask a question on the channel
 
     ## Windows (Note the double backslashes are necessary)
     #boincdatadir=C:\\ProgramData\\BOINC\\
-    #boincappdir=C:\\Program Files\\BOINC\\
 
     ## Linux
     #boincdatadir=/var/lib/boinc-client/


### PR DESCRIPTION
This is not used in the Gridcoin wallet and has not been for some time now.