### PR TITLE
Minor: Correct the term median to mean in the whitelist process

### DIFF
--- a/wiki/whitelist-process.md
+++ b/wiki/whitelist-process.md
@@ -27,7 +27,7 @@ The overall process looks like this:
 ### Criteria For Being Considered
 
 *  Project Work Availability Score (WAS) is green
-    * Means that the seven day median new credit / the 40 day median credit is greater than 0.1
+    * Means that the seven day mean new credit / the 40 day mean credit is greater than 0.1
         * Checks that there isn't a low amount of credit recently given out compared
           to its past
 ^


### PR DESCRIPTION
For some reason I wrote the term median earlier when the definition has always used the mean


The original definition was defined as

> WAS = Green If (**Mean** daily credit for 7 Days > (0.1 * **Mean** daily credit for 40 Days)) Else Red

https://github.com/gridcoin-community/Gridcoin-Tasks/issues/194

(Dividing the two gives you the same form as it exists on the site of

Mean daily credit for 7 Days / Mean daily credit for 40 Days > 0.1)



