### PR TITLE
Update to Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Ruby 3.1
+      - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
 
       - name: Install Bundle Dependencies 
         run: bundle install


### PR DESCRIPTION
Ruby 3.1 is EOL in May 2025.

Needs more review to ensure nothing breaks.