### PR TITLE
Remove ScienceStats faucet

### DIFF
--- a/exchange.htm
+++ b/exchange.htm
@@ -28,9 +28,6 @@ description: "Where to buy Gridcoin"
                 <h3>Free/Starter Gridcoin</h3>
                 <ul>
                     <li>
-                        Use the <a href="https://sciencestats.net" rel="nofollow">ScienceStats Proof-of-Work Faucet</a>
-                    </li>
-                    <li>
                         Use the <a href="https://gridcoin.ch/faucet.php">Gridcoin Switzerland Faucet</a>
                     </li>
                     <li>


### PR DESCRIPTION
The faucet appears to be serving malware. Remove it from the list.