### PR TITLE
Fix download links for current release asset naming (v3)

### DIFF
--- a/assets/js/fetch-release.js
+++ b/assets/js/fetch-release.js
@@ -1,29 +1,33 @@
-const allPlatforms = ["win64", "win32", "macos_arm", "macos"];
+const allPlatforms = ["win64", "macos-arm64", "macos-x86_64"];
 var platformsMissed = [...allPlatforms];
 
 function show(element){
     element.style.display = "";
 }
- 
+
 function doOtherPlatformsMatch(targetPlatform, name){
-    
+
     for (let comparePlatform of allPlatforms){
 
-        if (comparePlatform.length >= targetPlatform.length // don't match macos for macos_arm but do the other way around 
-            && comparePlatform !== targetPlatform 
+        if (comparePlatform.length >= targetPlatform.length
+            && comparePlatform !== targetPlatform
             && name.includes(targetPlatform)
             && name.includes(comparePlatform)
             ){
             return true;
         }
-        
+
     }
 
     return false;
 }
 
 function updateDownloads(data, platforms=allPlatforms, previousVersion=false) {
-    
+
+    if (!data || !data.assets) {
+        return;
+    }
+
     if(!previousVersion){
         document.getElementById("wallet-version").textContent  = 'Current Wallet Version: ' + data.name;
     }
@@ -31,7 +35,7 @@ function updateDownloads(data, platforms=allPlatforms, previousVersion=false) {
     let hotfixes = [];
 
     for (let assetFile of data.assets) {
-        
+
         const name = assetFile.name;
         const downloadURL = assetFile.browser_download_url;
 
@@ -46,14 +50,17 @@ function updateDownloads(data, platforms=allPlatforms, previousVersion=false) {
                     hotfixes.push(platform);
                 } else if (hotfixes.includes(platform)){
                     break; //if a hotfix already exists, don't update the file
-                } 
-                
+                }
+
                 const platformButton = document.getElementById(platform);
+                if (!platformButton) {
+                    continue;
+                }
                 platformButton.href = downloadURL;
                 show(platformButton);
 
                 if (name.includes("min")){
-                    const startOfMinVersion = name.indexOf("min-") + 4; 
+                    const startOfMinVersion = name.indexOf("min-") + 4;
                     const endOfFilename = name.lastIndexOf(".");
                     const minVersion = name.slice(startOfMinVersion, endOfFilename);
 
@@ -62,12 +69,14 @@ function updateDownloads(data, platforms=allPlatforms, previousVersion=false) {
 
                 if(previousVersion){
                     const versionWarn = document.getElementById(platform + "-version-warn");
-                    versionWarn.textContent += data.name;
-                    show(versionWarn);
+                    if (versionWarn) {
+                        versionWarn.textContent += data.name;
+                        show(versionWarn);
+                    }
                 }
 
                 platformsMissed = platformsMissed.filter(value => value !== platform); //remove platform from missed list
-                
+
                 break;
             }
         }
@@ -80,6 +89,10 @@ function fillInMissing(){
             .then(releases => releases.json())
             .then(releases =>{
                 for (let release of releases){
+                    // Skip pre-releases — only offer full releases as downloads.
+                    if (release.prerelease){
+                        continue;
+                    }
                     updateDownloads(release, platformsMissed, true);
                     if (platformsMissed.length === 0){
                         break;

--- a/index.htm
+++ b/index.htm
@@ -213,17 +213,10 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             <div class="col-12 col-sm-6 mb-4">
               <h4>Windows & Linux</h4>
               <!-- the 64/32 bit windows direct links won't be displayed while loading -->
-              <a id="win64" class="btn rounded-pill grcbtn m-1" style="display:none"> 
+              <a id="win64" class="btn rounded-pill grcbtn m-1" style="display:none">
                 64-bit Windows
               </a>
               <div id="win64-version-warn" class="text-warning fst-italic" style="display:none">
-                Using Old Version:
-              </div>
-              <br>
-              <a id="win32" class="btn rounded-pill grcbtn m-1" style="display:none">
-                32-bit Windows
-              </a>
-              <div id="win32-version-warn" class="text-warning fst-italic" style="display:none">
                 Using Old Version:
               </div>
               <br>
@@ -234,17 +227,17 @@ description: "Gridcoin is a cryptocurrency which rewards volunteer distributed c
             </div>
             <div class="col-12 col-sm-6 mb-4">
               <h4>macOS</h4>
-              <a id="macos" class="btn rounded-pill grcbtn m-1" style="display:none">
+              <a id="macos-x86_64" class="btn rounded-pill grcbtn m-1" style="display:none">
                 macOS Intel
               </a>
-              <div id="macos-version-warn" class="text-warning fst-italic" style="display:none">
-                  Using Old Version:
+              <div id="macos-x86_64-version-warn" class="text-warning fst-italic" style="display:none">
+                Using Old Version:
               </div>
               <br>
-              <a id="macos_arm" class="btn rounded-pill grcbtn m-1" style="display:none">
+              <a id="macos-arm64" class="btn rounded-pill grcbtn m-1" style="display:none">
                 macOS Apple Silicon
               </a>
-              <div id="macos_arm-version-warn" class="text-warning fst-italic" style="display:none">
+              <div id="macos-arm64-version-warn" class="text-warning fst-italic" style="display:none">
                 Using Old Version:
               </div>
               <br>


### PR DESCRIPTION
## Summary
- Update platform strings in `fetch-release.js` to match current CI asset names (`macos_arm` → `macos-arm64`, `macos` → `macos-x86_64`)
- Remove 32-bit Windows (`win32`) download button — no longer built
- Skip pre-releases in the `fillInMissing()` fallback so stale pre-release assets are not offered as downloads
- Add null guards for `platformButton`, `data.assets`, and `versionWarn` to prevent TypeError crashes
- Update HTML element IDs in `index.htm` to match new platform strings

## Regarding the errors from previous merges

We set up a local Jekyll test environment and were **unable to reproduce** the `TypeError: platformButton is null` error that was reported after the first merge. The JS logic, HTML element IDs, and GitHub API responses all align correctly in our testing:

- All three platform strings (`win64`, `macos-arm64`, `macos-x86_64`) match assets in the current 5.5.0.0 release
- All corresponding HTML element IDs exist in `index.htm`
- The `doOtherPlatformsMatch()` cross-match guard works correctly (no false matches against `.deb` assets, etc.)
- The `fillInMissing()` walk-back through older releases correctly skips pre-releases and does not produce spurious matches

**Possible cause of the previous errors:** The error at `fetch-release.js:52` (`platformButton.href = ...`) reported by @Barton26 references a line number from the **original** (pre-change) file, not from our PR's version. This suggests the browser may have been serving a cached copy of the old JS while the HTML had already been updated (or vice versa), causing an ID mismatch. GitHub Pages can take several minutes to propagate and CDN caches can hold stale assets.

**Recommendation for testing this merge:**
1. After merging, wait a few minutes for GitHub Pages to propagate
2. Hard-refresh the page (`Ctrl+Shift+R` or `Cmd+Shift+R`) to bypass browser cache
3. Open the browser developer console (F12 → Console) and check for errors
4. Verify that the Windows, macOS Intel, and macOS Apple Silicon download buttons appear and link to the correct 5.5.0.0 release assets

**Defensive changes in this version (v3):** Even though we couldn't reproduce the error, we added null guards at every `getElementById` call site (`platformButton`, `versionWarn`, `data.assets`) so that if a mismatch does occur for any reason, the script degrades gracefully rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)