### PR TITLE
Dynamic project whitelist + network analytics page

### DIFF
--- a/_includes/_footer.htm
+++ b/_includes/_footer.htm
@@ -73,6 +73,10 @@
                     <li>
                         <a href="/#Downloads">Wallet Downloads</a>
                     </li>
+                    <li role="presentation"><h6>Gridcoin Analytics</h6></li>
+                    <li>
+                        <a href="/guides/analytics.htm">Network Analytics</a>
+                    </li>
                     <li role="presentation"><h6>Block Explorers</h6></li>
                     <li>
                         <a href="https://www.gridcoinstats.eu/block">GridcoinStats</a>

--- a/_includes/_header.htm
+++ b/_includes/_header.htm
@@ -104,6 +104,9 @@
                             Pool/Stats
                         </a>
                     <div class="dropdown-menu" aria-labelledby="pool-stats-dropdown">
+                        <h6 class="dropdown-header text-center">Gridcoin Analytics</h6>
+                        <a class="dropdown-item" href="/guides/analytics.htm">Network Analytics</a>
+                        <div class="dropdown-divider"></div>
                         <h6 class="dropdown-header text-center">Gridcoin Pools</h6>
                         <a class="dropdown-item" href="https://www.grcpool.com/">grcpool</a>
                         <a class="dropdown-item" href="https://grc.arikado.ru/">Arikado Pool</a>

--- a/assets/css/gridcoin.css
+++ b/assets/css/gridcoin.css
@@ -273,6 +273,21 @@ dfn{
     color: inherit;
 }
 
+.status-greylisted {
+    color: #ada9a9;
+}
+.status-greylisted a {
+    color: #ada9a9;
+}
+.status-excluded {
+    color: #d4a849;
+}
+.status-excluded a {
+    color: #d4a849;
+}
+.status-active {
+}
+
 /*----end whitelist.erb----*/
 /*terminology.htm*/
 .terminology-top {

--- a/assets/js/analytics-api.js
+++ b/assets/js/analytics-api.js
@@ -1,0 +1,24 @@
+/**
+ * analytics-api.js — shared API URL resolver for the network-analytics
+ * page scripts. Mirrors the logic in fetch-whitelist.js / fetch-cpid-churn
+ * so that all plots follow the same host/port routing rules.
+ */
+
+window.analyticsApi = function(path) {
+    const host = window.location.hostname;
+    const port = window.location.port;
+    if (host === "gridcoin.us" || host === "www.gridcoin.us") {
+        return `https://api.gridcoin.us${path}`;
+    }
+    if (port === "4001") {
+        return `${window.location.protocol}//${host}:5000${path}`;
+    }
+    return path;
+};
+
+window.analyticsError = function(message) {
+    const el = document.getElementById("analytics-error");
+    if (!el) return;
+    el.textContent = message;
+    el.style.display = "";
+};

--- a/assets/js/chart-helpers.js
+++ b/assets/js/chart-helpers.js
@@ -5,13 +5,14 @@
  * Provides:
  *   window.analyticsReleasesPromise   — single fetch of /api/v1/history/releases
  *   window.buildReleaseAnnotations()  — Chart.js annotation objects for
- *                                       mandatory + leisure release markers
+ *                                       mandatory release markers
  *   window.buildQuarterlyAnnotations()— quarterly + annual vertical guides
  *   window.softGridScales()           — softer horizontal grid defaults
- *   window.registerAnalyticsChart()   — so the leisure-toggle can redraw all
  *
  * Chart.js v4 + chartjs-plugin-annotation v3 are pinned via CDN on the
- * consuming page (guides/analytics.htm).
+ * consuming page (guides/analytics.htm). Only mandatory releases are
+ * rendered; the API still returns leisure releases (the data layer is
+ * unchanged) but they are filtered out at annotation-build time.
  */
 
 // Single in-flight promise — all per-chart modules that await this share
@@ -42,19 +43,6 @@ window.analyticsReleasesPromise = (function() {
             return [];
         });
 })();
-
-// Global toggle state; driven by the "Show leisure releases" checkbox in
-// analytics.htm. Each release-annotation object reads this via its
-// `display` callback, so toggling doesn't require rebuilding the chart —
-// a cheap chart.update() is enough.
-window.analyticsShowLeisure = false;
-
-// Chart registry so the leisure toggle can ripple an update() across every
-// chart on the page.
-window.analyticsCharts = window.analyticsCharts || [];
-window.registerAnalyticsChart = function(chart) {
-    window.analyticsCharts.push(chart);
-};
 
 /**
  * Nearest-label lookup. Chart.js time-series charts use a category x-axis
@@ -91,16 +79,16 @@ function nearestLabel(labels, isoDate) {
 }
 
 /**
- * Chart.js-annotation-plugin objects, one per non-prerelease GitHub
- * release whose publication date falls within the chart's label range.
- * Mandatory releases are solid orange, leisure/unknown are dotted light
- * gray (and hidden unless the global toggle is on).
+ * Chart.js-annotation-plugin objects, one per mandatory GitHub release
+ * whose publication date falls within the chart's label range. The API
+ * still returns leisure/unknown releases — they're filtered out here so
+ * the rendered annotation set stays uncluttered.
  */
 // Snap window: a mandatory release within this many days *before* the
 // chart's first data point is snapped to the leftmost label with a "←"
 // prefix so the reader can see that the data window opens just after
 // that release (e.g. the 5.0.0.0 mandatory on 2020-09-04 vs. data start
-// on 2020-09-09). Non-mandatory pre-data releases are still skipped.
+// on 2020-09-09).
 const PRE_DATA_SNAP_DAYS = 30;
 
 window.buildReleaseAnnotations = function(releases, labels) {
@@ -109,11 +97,11 @@ window.buildReleaseAnnotations = function(releases, labels) {
     const firstLabelDate = new Date(labels[0]);
     releases.forEach((rel, i) => {
         if (!rel.published_at || !rel.tag) return;
+        if (rel.type !== "mandatory") return;
         const isoDate = rel.published_at.substring(0, 10);
-        const isMandatory = rel.type === "mandatory";
 
         let xVal = nearestLabel(labels, isoDate);
-        if (xVal === null && isMandatory && isoDate < labels[0]) {
+        if (xVal === null && isoDate < labels[0]) {
             const daysBefore = (firstLabelDate - new Date(isoDate)) / 86400000;
             if (daysBefore >= 0 && daysBefore <= PRE_DATA_SNAP_DAYS) {
                 // Snap one label inward from the edge (labels[1] not
@@ -127,31 +115,23 @@ window.buildReleaseAnnotations = function(releases, labels) {
         }
         if (xVal === null) return;
 
-        const labelText = rel.tag;
-
         annotations[`release-${i}`] = {
             type: "line",
             xMin: xVal,
             xMax: xVal,
-            borderColor: isMandatory
-                ? "rgba(255, 165, 0, 0.85)"      // mandatory: vivid orange
-                : "rgba(100, 180, 230, 0.70)",   // non-mandatory: soft blue (distinct from gridlines)
-            borderWidth: isMandatory ? 1.5 : 1,
-            borderDash: isMandatory ? [] : [5, 3],
-            display: function() {
-                return isMandatory || window.analyticsShowLeisure;
-            },
+            borderColor: "rgba(255, 165, 0, 0.85)",  // vivid orange
+            borderWidth: 1.5,
             // Small always-on label for mandatory releases (only 17 —
-            // they fit). Non-mandatory is marker-only to avoid clutter.
-            // `position: "end"` puts labels at the TOP of each vertical
-            // line, which keeps them away from the leftmost y-axis
-            // tick-label area (where `position: "start"` was causing
-            // the 5.0.0.0 edge-case label to be offset vs. interior
-            // labels). `yAdjust: 30` pushes each label ~30px below the
-            // chart top so they sit consistently within the plot area.
+            // they fit). `position: "end"` puts labels at the TOP of
+            // each vertical line, which keeps them away from the
+            // leftmost y-axis tick-label area (where `position: "start"`
+            // was causing the 5.0.0.0 edge-case label to be offset vs.
+            // interior labels). `yAdjust: 30` pushes each label ~30px
+            // below the chart top so they sit consistently within the
+            // plot area.
             label: {
-                display: isMandatory,
-                content: labelText,
+                display: true,
+                content: rel.tag,
                 position: "end",
                 yAdjust: 30,
                 rotation: 270,
@@ -378,23 +358,3 @@ window.buildChartAnnotations = function(labels, releases, activations) {
         ),
     );
 };
-
-// Wire the "Show leisure releases" checkbox once the DOM is ready.
-(function() {
-    function wire() {
-        const cb = document.getElementById("show-leisure-releases");
-        if (!cb) return;
-        window.analyticsShowLeisure = !!cb.checked;
-        cb.addEventListener("change", function(e) {
-            window.analyticsShowLeisure = !!e.target.checked;
-            (window.analyticsCharts || []).forEach(function(c) {
-                if (c && typeof c.update === "function") c.update("none");
-            });
-        });
-    }
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", wire);
-    } else {
-        wire();
-    }
-})();

--- a/assets/js/chart-helpers.js
+++ b/assets/js/chart-helpers.js
@@ -281,12 +281,75 @@ window.yearlyXTicksConfig = function(labels) {
 };
 
 /**
- * Convenience: given an array of labels (ISO date strings) and a release
- * list, produce the `plugins.annotation.annotations` object expected by
- * chartjs-plugin-annotation — releases plus quarterly guides, ready to
- * drop into a chart config.
+ * Block-version activation markers — dotted orange verticals at the
+ * dates each new block version actually went live on mainnet (post-
+ * grace-period transitions, *not* the dates the binaries were
+ * published). Same hue as mandatory-release markers but dashed and
+ * unlabeled, so a reader can distinguish "binary available" from
+ * "consensus rule live" — the gap between the two is the protocol
+ * grace period (~6.5 days currently).
+ *
+ * Activation list is fetched lazily from
+ * /api/v1/history/block-version-activations so the markers stay
+ * empirical (derived from the block_version recorded alongside each
+ * day's first_height) and never need code updates as new versions
+ * activate on mainnet.
  */
-window.buildChartAnnotations = function(labels, releases) {
+window.analyticsBlockVersionsPromise = (function() {
+    if (!window.analyticsApi) {
+        return Promise.resolve([]);
+    }
+    return fetch(window.analyticsApi("/api/v1/history/block-version-activations"))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => Array.isArray(payload.data) ? payload.data : [])
+        .catch(err => {
+            // Best-effort: missing markers are not fatal.
+            console.warn("Failed to load block-version-activations:", err);
+            return [];
+        });
+})();
+
+window.buildBlockVersionAnnotations = function(labels, activations) {
+    const annotations = {};
+    if (!labels || labels.length === 0 || !activations) return annotations;
+    activations.forEach((entry) => {
+        if (!entry.activation_date || entry.version == null) return;
+        const xVal = nearestLabel(labels, entry.activation_date);
+        if (xVal === null) return;
+        annotations[`bv-${entry.version}`] = {
+            type: "line",
+            xMin: xVal,
+            xMax: xVal,
+            borderColor: "rgba(255, 165, 0, 0.85)",
+            borderWidth: 1.5,
+            borderDash: [5, 3],
+            drawTime: "beforeDatasetsDraw",
+        };
+    });
+    return annotations;
+};
+
+window.analyticsBlockVersions = [];
+window.analyticsBlockVersionsPromise.then(arr => {
+    window.analyticsBlockVersions = arr;
+});
+
+/**
+ * Convenience: given an array of labels (ISO date strings), a release
+ * list, and a block-version activation list, produce the
+ * `plugins.annotation.annotations` object expected by
+ * chartjs-plugin-annotation — releases + quarterly guides + block-
+ * version-activation markers, ready to drop into a chart config.
+ *
+ * Block-version activations may not have arrived yet (the fetch is
+ * lazy); pass `activations` explicitly if you've awaited the promise,
+ * or rely on `window.analyticsBlockVersions` (cached after the promise
+ * resolves) for the current best-effort list.
+ */
+window.buildChartAnnotations = function(labels, releases, activations) {
     if (!labels || labels.length === 0) {
         return {};
     }
@@ -294,6 +357,10 @@ window.buildChartAnnotations = function(labels, releases) {
         {},
         window.buildQuarterlyAnnotations(labels),
         window.buildReleaseAnnotations(releases || [], labels),
+        window.buildBlockVersionAnnotations(
+            labels,
+            activations || window.analyticsBlockVersions,
+        ),
     );
 };
 

--- a/assets/js/chart-helpers.js
+++ b/assets/js/chart-helpers.js
@@ -327,6 +327,21 @@ window.buildBlockVersionAnnotations = function(labels, activations) {
             borderWidth: 1.5,
             borderDash: [5, 3],
             drawTime: "beforeDatasetsDraw",
+            // Small always-on label at the top, like mandatory releases
+            // but tinted to match the dashed style — distinguishes
+            // "consensus rule live" from "binary published".
+            label: {
+                display: true,
+                content: `v${entry.version}`,
+                position: "end",
+                yAdjust: 30,
+                rotation: 270,
+                backgroundColor: "rgba(20,20,20,0.55)",
+                color: "#ffd27a",
+                padding: { top: 2, bottom: 2, left: 4, right: 4 },
+                borderRadius: 3,
+                font: { size: 10 },
+            },
         };
     });
     return annotations;

--- a/assets/js/chart-helpers.js
+++ b/assets/js/chart-helpers.js
@@ -1,0 +1,318 @@
+/**
+ * chart-helpers.js — shared Chart.js options + annotations for the
+ * network-analytics time-series charts.
+ *
+ * Provides:
+ *   window.analyticsReleasesPromise   — single fetch of /api/v1/history/releases
+ *   window.buildReleaseAnnotations()  — Chart.js annotation objects for
+ *                                       mandatory + leisure release markers
+ *   window.buildQuarterlyAnnotations()— quarterly + annual vertical guides
+ *   window.softGridScales()           — softer horizontal grid defaults
+ *   window.registerAnalyticsChart()   — so the leisure-toggle can redraw all
+ *
+ * Chart.js v4 + chartjs-plugin-annotation v3 are pinned via CDN on the
+ * consuming page (guides/analytics.htm).
+ */
+
+// Single in-flight promise — all per-chart modules that await this share
+// the same fetch so we don't hammer the API proxy with N parallel requests
+// on page load. Resolved array is cached on window.analyticsReleases for
+// consumers that re-render charts after the initial page load (e.g. the
+// sand chart, which re-instantiates on every CPID change).
+window.analyticsReleases = [];
+window.analyticsReleasesPromise = (function() {
+    if (!window.analyticsApi) {
+        // analytics-api.js must load before this file.
+        return Promise.resolve([]);
+    }
+    return fetch(window.analyticsApi("/api/v1/history/releases"))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            const data = Array.isArray(payload.data) ? payload.data : [];
+            window.analyticsReleases = data;
+            return data;
+        })
+        .catch(err => {
+            // A chart failure is non-fatal — we still want the underlying
+            // data to render without release markers.
+            console.warn("Failed to load release annotations:", err);
+            return [];
+        });
+})();
+
+// Global toggle state; driven by the "Show leisure releases" checkbox in
+// analytics.htm. Each release-annotation object reads this via its
+// `display` callback, so toggling doesn't require rebuilding the chart —
+// a cheap chart.update() is enough.
+window.analyticsShowLeisure = false;
+
+// Chart registry so the leisure toggle can ripple an update() across every
+// chart on the page.
+window.analyticsCharts = window.analyticsCharts || [];
+window.registerAnalyticsChart = function(chart) {
+    window.analyticsCharts.push(chart);
+};
+
+/**
+ * Nearest-label lookup. Chart.js time-series charts use a category x-axis
+ * (string labels), so an `xMin` that isn't *exactly* one of the data
+ * labels gets placed unpredictably by the annotation plugin (in practice:
+ * piled at an edge). Snap every annotation date to the closest existing
+ * label. Returns null for dates outside the chart's date range so those
+ * annotations are skipped entirely (rather than collapsing onto the first
+ * or last data point).
+ *
+ * labels must be sorted ascending (ISO-8601 lex-sortable — guaranteed
+ * by our `ORDER BY obs_date` queries).
+ */
+function nearestLabel(labels, isoDate) {
+    if (!labels || labels.length === 0) return null;
+    if (isoDate < labels[0]) return null;
+    if (isoDate > labels[labels.length - 1]) return null;
+    // Binary search.
+    let lo = 0, hi = labels.length - 1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (labels[mid] === isoDate) return labels[mid];
+        if (labels[mid] < isoDate) lo = mid + 1;
+        else hi = mid - 1;
+    }
+    // lo is the insertion point; pick the closer neighbour.
+    if (lo === 0) return labels[0];
+    if (lo >= labels.length) return labels[labels.length - 1];
+    const prev = labels[lo - 1];
+    const next = labels[lo];
+    const distPrev = Math.abs(new Date(isoDate) - new Date(prev));
+    const distNext = Math.abs(new Date(isoDate) - new Date(next));
+    return distPrev <= distNext ? prev : next;
+}
+
+/**
+ * Chart.js-annotation-plugin objects, one per non-prerelease GitHub
+ * release whose publication date falls within the chart's label range.
+ * Mandatory releases are solid orange, leisure/unknown are dotted light
+ * gray (and hidden unless the global toggle is on).
+ */
+// Snap window: a mandatory release within this many days *before* the
+// chart's first data point is snapped to the leftmost label with a "←"
+// prefix so the reader can see that the data window opens just after
+// that release (e.g. the 5.0.0.0 mandatory on 2020-09-04 vs. data start
+// on 2020-09-09). Non-mandatory pre-data releases are still skipped.
+const PRE_DATA_SNAP_DAYS = 30;
+
+window.buildReleaseAnnotations = function(releases, labels) {
+    const annotations = {};
+    if (!labels || labels.length === 0) return annotations;
+    const firstLabelDate = new Date(labels[0]);
+    releases.forEach((rel, i) => {
+        if (!rel.published_at || !rel.tag) return;
+        const isoDate = rel.published_at.substring(0, 10);
+        const isMandatory = rel.type === "mandatory";
+
+        let xVal = nearestLabel(labels, isoDate);
+        if (xVal === null && isMandatory && isoDate < labels[0]) {
+            const daysBefore = (firstLabelDate - new Date(isoDate)) / 86400000;
+            if (daysBefore >= 0 && daysBefore <= PRE_DATA_SNAP_DAYS) {
+                // Snap one label inward from the edge (labels[1] not
+                // labels[0]). An annotation exactly at labels[0] is
+                // rendered clipped by the chart border — the line looks
+                // half-width and the label anchor is displaced. One day
+                // inward is visually identical at yearly tick resolution
+                // but avoids the edge-clipping artifact.
+                xVal = labels.length > 1 ? labels[1] : labels[0];
+            }
+        }
+        if (xVal === null) return;
+
+        const labelText = rel.tag;
+
+        annotations[`release-${i}`] = {
+            type: "line",
+            xMin: xVal,
+            xMax: xVal,
+            borderColor: isMandatory
+                ? "rgba(255, 165, 0, 0.85)"      // mandatory: vivid orange
+                : "rgba(100, 180, 230, 0.70)",   // non-mandatory: soft blue (distinct from gridlines)
+            borderWidth: isMandatory ? 1.5 : 1,
+            borderDash: isMandatory ? [] : [5, 3],
+            display: function() {
+                return isMandatory || window.analyticsShowLeisure;
+            },
+            // Small always-on label for mandatory releases (only 17 —
+            // they fit). Non-mandatory is marker-only to avoid clutter.
+            // `position: "end"` puts labels at the TOP of each vertical
+            // line, which keeps them away from the leftmost y-axis
+            // tick-label area (where `position: "start"` was causing
+            // the 5.0.0.0 edge-case label to be offset vs. interior
+            // labels). `yAdjust: 30` pushes each label ~30px below the
+            // chart top so they sit consistently within the plot area.
+            label: {
+                display: isMandatory,
+                content: labelText,
+                position: "end",
+                yAdjust: 30,
+                rotation: 270,
+                backgroundColor: "rgba(20,20,20,0.55)",
+                color: "#ffd27a",
+                padding: { top: 2, bottom: 2, left: 4, right: 4 },
+                borderRadius: 3,
+                font: { size: 10 },
+            },
+        };
+    });
+    return annotations;
+};
+
+/**
+ * Quarterly vertical guides snapped to the nearest data-label date.
+ * Jan 1 gets a slightly brighter line (year boundary); Apr / Jul / Oct
+ * are dimmer dotted. Both sit behind the data.
+ */
+window.buildQuarterlyAnnotations = function(labels) {
+    const annotations = {};
+    if (!labels || labels.length === 0) return annotations;
+    const min = new Date(labels[0]);
+    const max = new Date(labels[labels.length - 1]);
+    if (isNaN(min) || isNaN(max)) return annotations;
+    const startYear = min.getUTCFullYear();
+    const endYear = max.getUTCFullYear();
+    const quarterMonths = [0, 3, 6, 9];
+    for (let y = startYear; y <= endYear; y++) {
+        for (const m of quarterMonths) {
+            const d = new Date(Date.UTC(y, m, 1));
+            if (d < min || d > max) continue;
+            const iso = d.toISOString().substring(0, 10);
+            const xVal = nearestLabel(labels, iso);
+            if (xVal === null) continue;
+            const isYearBoundary = (m === 0);
+            annotations[`q-${iso}`] = {
+                type: "line",
+                xMin: xVal,
+                xMax: xVal,
+                borderColor: isYearBoundary
+                    ? "rgba(200, 200, 200, 0.28)"
+                    : "rgba(200, 200, 200, 0.14)",
+                borderWidth: 1,
+                borderDash: isYearBoundary ? [] : [2, 4],
+                drawTime: "beforeDatasetsDraw",
+            };
+        }
+    }
+    return annotations;
+};
+
+/**
+ * Common scales styling: soft light-alpha horizontal gridlines that work
+ * on both light and dark themes, and a very subtle x-axis grid so the
+ * quarterly annotations dominate horizontally.
+ */
+window.softGridStyle = function() {
+    return {
+        xGrid: {
+            // Hide the per-label vertical gridlines — with ~2000 daily
+            // labels the cumulative stipple overwhelms the chart. The
+            // quarterly and year-boundary annotations provide the
+            // visual vertical grid.
+            color: "transparent",
+            drawTicks: false,
+            drawOnChartArea: false,
+        },
+        yGrid: {
+            color: "rgba(200, 200, 200, 0.32)",
+            drawTicks: true,
+            drawOnChartArea: true,
+        },
+    };
+};
+
+/**
+ * Ticks config for a category x-axis of daily ISO-date labels. Replaces
+ * Chart.js autoSkip sampling (which picked uneven dates like "2021-02-24")
+ * with explicit Jan-1 year markers only, displayed as "1/1/yyyy". The
+ * nearest existing label to each year's Jan 1 is used (data gaps around
+ * the new year get the closest available label instead). The first
+ * (partial) year in the series is skipped — if data starts in September
+ * there's no sensible "1/1/<firstYear>" tick to show.
+ *
+ * Returned object is meant to be merged into `scales.x.ticks`.
+ */
+window.yearlyXTicksConfig = function(labels) {
+    const base = { autoSkip: false, maxRotation: 0 };
+    if (!labels || labels.length === 0) return base;
+
+    const displayByIndex = new Map();
+    const firstYear = parseInt(labels[0].substring(0, 4), 10);
+    const lastYear = parseInt(labels[labels.length - 1].substring(0, 4), 10);
+    if (!Number.isFinite(firstYear) || !Number.isFinite(lastYear)) return base;
+
+    for (let y = firstYear + 1; y <= lastYear; y++) {
+        const jan1 = y + "-01-01";
+        // Binary search for jan1 insertion index in labels.
+        let lo = 0, hi = labels.length - 1;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1;
+            if (labels[mid] === jan1) { lo = mid; break; }
+            if (labels[mid] < jan1) lo = mid + 1;
+            else hi = mid - 1;
+        }
+        // Prefer the label at-or-after jan1 if it's in year y, else the
+        // one immediately before if it's in year y, else skip.
+        let candidate = -1;
+        if (lo < labels.length && labels[lo].startsWith(y + "-")) {
+            candidate = lo;
+        } else if (lo > 0 && labels[lo - 1].startsWith(y + "-")) {
+            candidate = lo - 1;
+        }
+        if (candidate >= 0) {
+            displayByIndex.set(candidate, "1/1/" + y);
+        }
+    }
+
+    return {
+        autoSkip: false,
+        maxRotation: 0,
+        callback: function(_value, index) {
+            return displayByIndex.get(index) || "";
+        },
+    };
+};
+
+/**
+ * Convenience: given an array of labels (ISO date strings) and a release
+ * list, produce the `plugins.annotation.annotations` object expected by
+ * chartjs-plugin-annotation — releases plus quarterly guides, ready to
+ * drop into a chart config.
+ */
+window.buildChartAnnotations = function(labels, releases) {
+    if (!labels || labels.length === 0) {
+        return {};
+    }
+    return Object.assign(
+        {},
+        window.buildQuarterlyAnnotations(labels),
+        window.buildReleaseAnnotations(releases || [], labels),
+    );
+};
+
+// Wire the "Show leisure releases" checkbox once the DOM is ready.
+(function() {
+    function wire() {
+        const cb = document.getElementById("show-leisure-releases");
+        if (!cb) return;
+        window.analyticsShowLeisure = !!cb.checked;
+        cb.addEventListener("change", function(e) {
+            window.analyticsShowLeisure = !!e.target.checked;
+            (window.analyticsCharts || []).forEach(function(c) {
+                if (c && typeof c.update === "function") c.update("none");
+            });
+        });
+    }
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", wire);
+    } else {
+        wire();
+    }
+})();

--- a/assets/js/fetch-cpid-churn.js
+++ b/assets/js/fetch-cpid-churn.js
@@ -95,7 +95,6 @@ function renderCpidChurnChart(records, releases, activations) {
             },
         },
     });
-    if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
 }
 
 function initCpidChurn() {

--- a/assets/js/fetch-cpid-churn.js
+++ b/assets/js/fetch-cpid-churn.js
@@ -5,26 +5,11 @@
  * active / churn-in / churn-out line chart with Chart.js.
  */
 
-const CHURN_API_URL = (function() {
-    const host = window.location.hostname;
-    const port = window.location.port;
-    // Production: gridcoin.us uses the dedicated API subdomain.
-    if (host === "gridcoin.us" || host === "www.gridcoin.us") {
-        return "https://api.gridcoin.us/api/v1/history/cpid-churn";
-    }
-    // Jekyll dev server binds to port 4001 and has no reverse-proxy of
-    // its own — hop sideways to the FastAPI proxy on :5000 of the same
-    // host. Works for 127.0.0.1/localhost and for any LAN hostname the
-    // dev server has been bound to.
-    if (port === "4001") {
-        return `${window.location.protocol}//${host}:5000/api/v1/history/cpid-churn`;
-    }
-    // Everything else (Caddy staging on :81, same-origin prod reverse-proxy)
-    // serves the API under the same origin via /api/v1/*.
-    return "/api/v1/history/cpid-churn";
-})();
+const CHURN_API_URL = window.analyticsApi
+    ? window.analyticsApi("/api/v1/history/cpid-churn")
+    : "/api/v1/history/cpid-churn";
 
-function renderCpidChurnChart(records) {
+function renderCpidChurnChart(records, releases) {
     const canvas = document.getElementById("cpid-churn-chart");
     if (!canvas || !window.Chart) return;
 
@@ -33,7 +18,12 @@ function renderCpidChurnChart(records) {
     const churnIn = records.map(r => r.churn_in);
     const churnOut = records.map(r => r.churn_out);
 
-    new Chart(canvas, {
+    const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
+    const annotations = window.buildChartAnnotations
+        ? window.buildChartAnnotations(labels, releases)
+        : {};
+
+    const chart = new Chart(canvas, {
         type: "line",
         data: {
             labels: labels,
@@ -80,16 +70,21 @@ function renderCpidChurnChart(records) {
                 },
                 legend: { position: "bottom" },
                 tooltip: { mode: "index", intersect: false },
+                annotation: { annotations },
             },
             scales: {
                 x: {
-                    ticks: { maxTicksLimit: 12, autoSkip: true },
+                    ticks: window.yearlyXTicksConfig
+                        ? window.yearlyXTicksConfig(labels)
+                        : { maxTicksLimit: 12, autoSkip: true },
                     title: { display: true, text: "Date" },
+                    grid: grid.xGrid,
                 },
                 y: {
                     beginAtZero: false,
                     position: "left",
                     title: { display: true, text: "Active CPIDs" },
+                    grid: grid.yGrid,
                 },
                 y1: {
                     beginAtZero: true,
@@ -100,20 +95,26 @@ function renderCpidChurnChart(records) {
             },
         },
     });
+    if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
 }
 
 function initCpidChurn() {
     const errBanner = document.getElementById("analytics-error");
-    fetch(CHURN_API_URL)
-        .then(r => {
+    // Fetch the data and the release list in parallel; releases may arrive
+    // slightly later but that's fine — the chart will render without the
+    // annotation overlay if the releases request fails.
+    Promise.all([
+        fetch(CHURN_API_URL).then(r => {
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             return r.json();
-        })
-        .then(payload => {
+        }),
+        window.analyticsReleasesPromise || Promise.resolve([]),
+    ])
+        .then(([payload, releases]) => {
             if (!payload || !Array.isArray(payload.data)) {
                 throw new Error("Unexpected API payload");
             }
-            renderCpidChurnChart(payload.data);
+            renderCpidChurnChart(payload.data, releases || []);
         })
         .catch(err => {
             console.error("Failed to load cpid-churn:", err);

--- a/assets/js/fetch-cpid-churn.js
+++ b/assets/js/fetch-cpid-churn.js
@@ -1,0 +1,132 @@
+/**
+ * fetch-cpid-churn.js — Daily CPID activity time-series chart.
+ *
+ * Pulls summary_cpid_churn data from the analytics API and renders an
+ * active / churn-in / churn-out line chart with Chart.js.
+ */
+
+const CHURN_API_URL = (function() {
+    const host = window.location.hostname;
+    const port = window.location.port;
+    // Production: gridcoin.us uses the dedicated API subdomain.
+    if (host === "gridcoin.us" || host === "www.gridcoin.us") {
+        return "https://api.gridcoin.us/api/v1/history/cpid-churn";
+    }
+    // Jekyll dev server binds to port 4001 and has no reverse-proxy of
+    // its own — hop sideways to the FastAPI proxy on :5000 of the same
+    // host. Works for 127.0.0.1/localhost and for any LAN hostname the
+    // dev server has been bound to.
+    if (port === "4001") {
+        return `${window.location.protocol}//${host}:5000/api/v1/history/cpid-churn`;
+    }
+    // Everything else (Caddy staging on :81, same-origin prod reverse-proxy)
+    // serves the API under the same origin via /api/v1/*.
+    return "/api/v1/history/cpid-churn";
+})();
+
+function renderCpidChurnChart(records) {
+    const canvas = document.getElementById("cpid-churn-chart");
+    if (!canvas || !window.Chart) return;
+
+    const labels = records.map(r => r.obs_date);
+    const active = records.map(r => r.active_cpids);
+    const churnIn = records.map(r => r.churn_in);
+    const churnOut = records.map(r => r.churn_out);
+
+    new Chart(canvas, {
+        type: "line",
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: "Active CPIDs",
+                    data: active,
+                    borderColor: "#2d6cdf",
+                    backgroundColor: "rgba(45, 108, 223, 0.1)",
+                    yAxisID: "y",
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    fill: true,
+                },
+                {
+                    label: "Churn in",
+                    data: churnIn,
+                    borderColor: "#2ca02c",
+                    yAxisID: "y1",
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0.2,
+                },
+                {
+                    label: "Churn out",
+                    data: churnOut,
+                    borderColor: "#d62728",
+                    yAxisID: "y1",
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0.2,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: "index", intersect: false },
+            plugins: {
+                title: {
+                    display: true,
+                    text: "Daily active CPIDs (left axis) and daily churn in/out (right axis)",
+                },
+                legend: { position: "bottom" },
+                tooltip: { mode: "index", intersect: false },
+            },
+            scales: {
+                x: {
+                    ticks: { maxTicksLimit: 12, autoSkip: true },
+                    title: { display: true, text: "Date" },
+                },
+                y: {
+                    beginAtZero: false,
+                    position: "left",
+                    title: { display: true, text: "Active CPIDs" },
+                },
+                y1: {
+                    beginAtZero: true,
+                    position: "right",
+                    title: { display: true, text: "Churn (CPIDs/day)" },
+                    grid: { drawOnChartArea: false },
+                },
+            },
+        },
+    });
+}
+
+function initCpidChurn() {
+    const errBanner = document.getElementById("analytics-error");
+    fetch(CHURN_API_URL)
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            if (!payload || !Array.isArray(payload.data)) {
+                throw new Error("Unexpected API payload");
+            }
+            renderCpidChurnChart(payload.data);
+        })
+        .catch(err => {
+            console.error("Failed to load cpid-churn:", err);
+            if (errBanner) {
+                errBanner.textContent =
+                    "Couldn't load live analytics data. Please try again later.";
+                errBanner.style.display = "";
+            }
+        });
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCpidChurn);
+} else {
+    initCpidChurn();
+}

--- a/assets/js/fetch-cpid-churn.js
+++ b/assets/js/fetch-cpid-churn.js
@@ -9,7 +9,7 @@ const CHURN_API_URL = window.analyticsApi
     ? window.analyticsApi("/api/v1/history/cpid-churn")
     : "/api/v1/history/cpid-churn";
 
-function renderCpidChurnChart(records, releases) {
+function renderCpidChurnChart(records, releases, activations) {
     const canvas = document.getElementById("cpid-churn-chart");
     if (!canvas || !window.Chart) return;
 
@@ -20,7 +20,7 @@ function renderCpidChurnChart(records, releases) {
 
     const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
     const annotations = window.buildChartAnnotations
-        ? window.buildChartAnnotations(labels, releases)
+        ? window.buildChartAnnotations(labels, releases, activations)
         : {};
 
     const chart = new Chart(canvas, {
@@ -109,12 +109,13 @@ function initCpidChurn() {
             return r.json();
         }),
         window.analyticsReleasesPromise || Promise.resolve([]),
+        window.analyticsBlockVersionsPromise || Promise.resolve([]),
     ])
-        .then(([payload, releases]) => {
+        .then(([payload, releases, activations]) => {
             if (!payload || !Array.isArray(payload.data)) {
                 throw new Error("Unexpected API payload");
             }
-            renderCpidChurnChart(payload.data, releases || []);
+            renderCpidChurnChart(payload.data, releases || [], activations || []);
         })
         .catch(err => {
             console.error("Failed to load cpid-churn:", err);

--- a/assets/js/fetch-cpid-churn.js
+++ b/assets/js/fetch-cpid-churn.js
@@ -81,7 +81,7 @@ function renderCpidChurnChart(records, releases, activations) {
                     grid: grid.xGrid,
                 },
                 y: {
-                    beginAtZero: false,
+                    beginAtZero: true,
                     position: "left",
                     title: { display: true, text: "Active CPIDs" },
                     grid: grid.yGrid,

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -98,12 +98,13 @@ function renderSandChart(rows) {
 
     const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
     // The sand chart re-instantiates on every CPID selection. Reading the
-    // cached resolved list keeps this sync — on the very first selection
-    // before the releases fetch has settled we just skip the release
-    // markers and fall back to quarterly-only annotations.
+    // cached resolved lists keeps this sync — on the very first selection
+    // before the releases / block-versions fetches have settled we just
+    // skip those markers and fall back to quarterly-only annotations.
     const releases = window.analyticsReleases || [];
+    const activations = window.analyticsBlockVersions || [];
     const annotations = window.buildChartAnnotations
-        ? window.buildChartAnnotations(labels, releases)
+        ? window.buildChartAnnotations(labels, releases, activations)
         : {};
 
     sandState.chart = new Chart(canvas, {

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -145,10 +145,9 @@ function renderSandChart(rows) {
     if (window.registerAnalyticsChart) window.registerAnalyticsChart(sandState.chart);
 }
 
-// Exposed globally so the top-CPIDs leaderboard can drive the sand chart
-// programmatically when a user clicks a CPID in the table.
-window.loadSandChart = function() { return loadSandChart(); };
-
+// `loadSandChart` is callable as `window.loadSandChart` from
+// fetch-top-cpids.js — top-level function declarations in classic
+// scripts are automatically global-object properties.
 function loadSandChart() {
     const input   = document.getElementById("cpid-sand-input");
     const loading = document.getElementById("cpid-sand-loading");

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -143,7 +143,6 @@ function renderSandChart(rows) {
             },
         },
     });
-    if (window.registerAnalyticsChart) window.registerAnalyticsChart(sandState.chart);
 }
 
 // `loadSandChart` is callable as `window.loadSandChart` from

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -145,6 +145,10 @@ function renderSandChart(rows) {
     if (window.registerAnalyticsChart) window.registerAnalyticsChart(sandState.chart);
 }
 
+// Exposed globally so the top-CPIDs leaderboard can drive the sand chart
+// programmatically when a user clicks a CPID in the table.
+window.loadSandChart = function() { return loadSandChart(); };
+
 function loadSandChart() {
     const input   = document.getElementById("cpid-sand-input");
     const loading = document.getElementById("cpid-sand-loading");

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -1,0 +1,185 @@
+/**
+ * fetch-cpid-sand.js — stacked-area ("sand") chart of a single CPID's
+ * magnitude distributed across projects over time.
+ *
+ * Loads the full CPID list on init to populate a native <datalist>-
+ * driven autocomplete; renders the sand chart on demand when the user
+ * picks a CPID and hits the Show button. Re-uses Chart.js already
+ * loaded by the analytics page.
+ */
+
+function hslColor(i, total) {
+    const h = Math.round((360 * i) / Math.max(total, 1));
+    return `hsl(${h}, 65%, 48%)`;
+}
+
+const sandState = {
+    chart: null,
+    cpidsByHex: new Map(),
+};
+
+function populateCpidDatalist() {
+    const list  = document.getElementById("cpid-sand-list");
+    const input = document.getElementById("cpid-sand-input");
+    const hint  = document.getElementById("cpid-sand-autocomplete-hint");
+    if (!list) return;
+
+    if (hint) hint.textContent = "Loading autocomplete list…";
+
+    fetch(window.analyticsApi("/api/v1/history/cpids"))
+        .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+        .then(payload => {
+            const rows = payload.data || [];
+            const frag = document.createDocumentFragment();
+            for (const row of rows) {
+                sandState.cpidsByHex.set(row.cpid, row);
+                const opt = document.createElement("option");
+                opt.value = row.cpid;
+                // Label shown in the dropdown hint column — days active + last seen.
+                opt.label = `active ${row.days_active}d · last ${row.last_seen}`;
+                frag.appendChild(opt);
+            }
+            list.appendChild(frag);
+            // Chromium quirk: datalist options appended while the input is
+            // focused aren't re-indexed until focus is lost and regained.
+            // Firing a synthetic `input` event forces a re-scan so prefix
+            // matching starts working immediately.
+            if (input) input.dispatchEvent(new Event("input"));
+            if (hint) hint.textContent = `${rows.length.toLocaleString()} CPIDs available for autocomplete.`;
+        })
+        .catch(err => {
+            console.error("Failed to load CPID list:", err);
+            if (hint) hint.textContent = "Couldn't load autocomplete list.";
+            window.analyticsError("Couldn't load CPID autocomplete list.");
+        });
+}
+
+function pivotByProject(rows) {
+    // Input: [{obs_date, project, mag}, ...] sorted by date, project.
+    // Output: {labels: [dates], datasets: [{label: project, data: [mag-per-date]}, ...]}
+    const dateSet = new Set();
+    const perProject = new Map();
+    for (const r of rows) {
+        dateSet.add(r.obs_date);
+        if (!perProject.has(r.project)) perProject.set(r.project, new Map());
+        perProject.get(r.project).set(r.obs_date, r.mag);
+    }
+    const dates = Array.from(dateSet).sort();
+    const projects = Array.from(perProject.keys()).sort();
+    const datasets = projects.map((p, i) => ({
+        label: p,
+        data: dates.map(d => perProject.get(p).get(d) ?? 0),
+        borderColor: hslColor(i, projects.length),
+        backgroundColor: hslColor(i, projects.length),
+        borderWidth: 1,
+        pointRadius: 0,
+        tension: 0.1,
+        fill: true,
+    }));
+    return { labels: dates, datasets };
+}
+
+function renderSandChart(rows) {
+    const canvas = document.getElementById("cpid-sand-chart");
+    if (!canvas || !window.Chart) return;
+
+    if (sandState.chart) {
+        sandState.chart.destroy();
+        sandState.chart = null;
+    }
+
+    if (rows.length === 0) {
+        const ctx = canvas.getContext("2d");
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        return;
+    }
+
+    const { labels, datasets } = pivotByProject(rows);
+
+    sandState.chart = new Chart(canvas, {
+        type: "line",
+        data: { labels, datasets },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: "index", intersect: false },
+            plugins: {
+                title: {
+                    display: true,
+                    text: "CPID magnitude by project over time (stacked)",
+                },
+                legend: {
+                    position: "bottom",
+                    labels: { boxWidth: 12, padding: 8 },
+                },
+                tooltip: { mode: "index", intersect: false },
+            },
+            scales: {
+                x: {
+                    ticks: { maxTicksLimit: 12, autoSkip: true },
+                    title: { display: true, text: "Date" },
+                },
+                y: {
+                    stacked: true,
+                    beginAtZero: true,
+                    title: { display: true, text: "Magnitude" },
+                },
+            },
+        },
+    });
+}
+
+function loadSandChart() {
+    const input   = document.getElementById("cpid-sand-input");
+    const loading = document.getElementById("cpid-sand-loading");
+    const status  = document.getElementById("cpid-sand-status");
+
+    const cpid = (input ? input.value.trim().toLowerCase() : "");
+    if (!/^[0-9a-f]{32}$/.test(cpid)) {
+        if (status) status.textContent = "Enter a 32-character hex CPID.";
+        return;
+    }
+    if (status) {
+        const meta = sandState.cpidsByHex.get(cpid);
+        if (meta) {
+            status.textContent = `first seen ${meta.first_seen}, last seen ${meta.last_seen}, active ${meta.days_active} days, lifetime mag ${Math.round(meta.lifetime_mag_sum).toLocaleString()}`;
+        } else {
+            status.textContent = "CPID not found in history — chart will be empty.";
+        }
+    }
+
+    if (loading) loading.style.display = "";
+    fetch(window.analyticsApi(`/api/v1/history/cpid-project-magnitude?cpid=${encodeURIComponent(cpid)}`))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            renderSandChart(payload.data || []);
+        })
+        .catch(err => {
+            console.error("Failed to load cpid-project-magnitude:", err);
+            window.analyticsError("Couldn't load CPID sand chart data.");
+        })
+        .finally(() => {
+            if (loading) loading.style.display = "none";
+        });
+}
+
+function initCpidSand() {
+    const input = document.getElementById("cpid-sand-input");
+    const btn   = document.getElementById("cpid-sand-render");
+
+    if (btn)   btn.addEventListener("click", loadSandChart);
+    if (input) input.addEventListener("keydown", e => {
+        if (e.key === "Enter") { e.preventDefault(); loadSandChart(); }
+    });
+
+    populateCpidDatalist();
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCpidSand);
+} else {
+    initCpidSand();
+}

--- a/assets/js/fetch-cpid-sand.js
+++ b/assets/js/fetch-cpid-sand.js
@@ -96,6 +96,16 @@ function renderSandChart(rows) {
 
     const { labels, datasets } = pivotByProject(rows);
 
+    const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
+    // The sand chart re-instantiates on every CPID selection. Reading the
+    // cached resolved list keeps this sync — on the very first selection
+    // before the releases fetch has settled we just skip the release
+    // markers and fall back to quarterly-only annotations.
+    const releases = window.analyticsReleases || [];
+    const annotations = window.buildChartAnnotations
+        ? window.buildChartAnnotations(labels, releases)
+        : {};
+
     sandState.chart = new Chart(canvas, {
         type: "line",
         data: { labels, datasets },
@@ -113,20 +123,26 @@ function renderSandChart(rows) {
                     labels: { boxWidth: 12, padding: 8 },
                 },
                 tooltip: { mode: "index", intersect: false },
+                annotation: { annotations },
             },
             scales: {
                 x: {
-                    ticks: { maxTicksLimit: 12, autoSkip: true },
+                    ticks: window.yearlyXTicksConfig
+                        ? window.yearlyXTicksConfig(labels)
+                        : { maxTicksLimit: 12, autoSkip: true },
                     title: { display: true, text: "Date" },
+                    grid: grid.xGrid,
                 },
                 y: {
                     stacked: true,
                     beginAtZero: true,
                     title: { display: true, text: "Magnitude" },
+                    grid: grid.yGrid,
                 },
             },
         },
     });
+    if (window.registerAnalyticsChart) window.registerAnalyticsChart(sandState.chart);
 }
 
 function loadSandChart() {

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -18,15 +18,36 @@ const MRC_API_URL = window.analyticsApi
     ? window.analyticsApi("/api/v1/history/mrc-daily")
     : "/api/v1/history/mrc-daily";
 
+// Rolling-mean window. Trailing (each point is the average of the
+// preceding `MA_WINDOW` days including itself), so the right edge is
+// "honest" rather than running ahead in time. The first MA_WINDOW-1
+// days are computed over the available history (a partial window) so
+// the series starts at the data's start rather than `MA_WINDOW` days
+// later — visually cleaner and the partial-window distortion is small
+// against the noise we're trying to suppress.
+const MA_WINDOW = 7;
+
+function rollingMean(arr, window) {
+    const out = new Array(arr.length);
+    let sum = 0;
+    for (let i = 0; i < arr.length; i++) {
+        sum += arr[i];
+        if (i >= window) sum -= arr[i - window];
+        const denom = Math.min(i + 1, window);
+        out[i] = sum / denom;
+    }
+    return out;
+}
+
 function renderMrcDailyChart(records, releases) {
     const canvas = document.getElementById("mrc-daily-chart");
     if (!canvas || !window.Chart) return;
 
     const labels = records.map(r => r.obs_date);
-    const netToResearcher = records.map(r => r.net_to_researcher);
-    const foundationFees  = records.map(r => r.foundation_fees);
-    const stakerFees      = records.map(r => r.staker_fees);
-    const mrcsPaid        = records.map(r => r.mrcs_paid);
+    const netToResearcher = rollingMean(records.map(r => r.net_to_researcher), MA_WINDOW);
+    const foundationFees  = rollingMean(records.map(r => r.foundation_fees),   MA_WINDOW);
+    const stakerFees      = rollingMean(records.map(r => r.staker_fees),       MA_WINDOW);
+    const mrcsPaid        = rollingMean(records.map(r => r.mrcs_paid),         MA_WINDOW);
 
     const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
     const annotations = window.buildChartAnnotations
@@ -99,7 +120,7 @@ function renderMrcDailyChart(records, releases) {
             plugins: {
                 title: {
                     display: true,
-                    text: "Daily MRC payments — net-to-researcher / foundation fees / staker fees (stacked, left); MRCs/day count (right)",
+                    text: "Daily MRC payments (7-day moving average) — net-to-researcher / foundation fees / staker fees (stacked, left); MRCs/day count (right)",
                 },
                 legend: { position: "bottom" },
                 tooltip: { mode: "index", intersect: false },

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -71,7 +71,7 @@ function rollingMean(arr, halfBefore, halfAfter) {
 
 const MA_SUFFIX = " (14d MA)";
 
-function renderMrcDailyChart(records, releases) {
+function renderMrcDailyChart(records, releases, activations) {
     const canvas = document.getElementById("mrc-daily-chart");
     if (!canvas || !window.Chart) return;
 
@@ -83,7 +83,7 @@ function renderMrcDailyChart(records, releases) {
 
     const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
     const annotations = window.buildChartAnnotations
-        ? window.buildChartAnnotations(labels, releases)
+        ? window.buildChartAnnotations(labels, releases, activations)
         : {};
 
     const chart = new Chart(canvas, {
@@ -200,8 +200,9 @@ function initMrcDaily() {
             return r.json();
         }),
         window.analyticsReleasesPromise || Promise.resolve([]),
+        window.analyticsBlockVersionsPromise || Promise.resolve([]),
     ])
-        .then(([mrcPayload, cpidPayload, releases]) => {
+        .then(([mrcPayload, cpidPayload, releases, activations]) => {
             if (!mrcPayload || !Array.isArray(mrcPayload.data)) {
                 throw new Error("Unexpected mrc-daily payload");
             }
@@ -210,7 +211,7 @@ function initMrcDaily() {
             }
             const axisLabels = cpidPayload.data.map(r => r.obs_date);
             const aligned = alignMrcToLabels(mrcPayload.data, axisLabels);
-            renderMrcDailyChart(aligned, releases || []);
+            renderMrcDailyChart(aligned, releases || [], activations || []);
         })
         .catch(err => {
             console.error("Failed to load mrc-daily:", err);

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -183,7 +183,6 @@ function renderMrcDailyChart(records, releases, activations) {
             },
         },
     });
-    if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
 }
 
 function initMrcDaily() {

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -1,0 +1,165 @@
+/**
+ * fetch-mrc-daily.js — daily MRC (Manual Research Claim) payment chart.
+ *
+ * Stacked area on the primary y-axis decomposes each day's gross
+ * research-reward MRC volume into its three end-of-flow buckets:
+ *   net-to-researcher + foundation fees + staker fees
+ * (the stacked total reproduces gross_research). On the secondary
+ * y-axis a thin line shows the per-day MRC count, which is order-of-
+ * magnitude smaller than the GRC amounts and benefits from its own
+ * scale.
+ *
+ * Source: /api/v1/history/mrc-daily, populated by ingest_mrc.py from
+ * `getmrcinfo false * <first_height> <last_height>` calls bracketed
+ * by daily_block_boundaries.
+ */
+
+const MRC_API_URL = window.analyticsApi
+    ? window.analyticsApi("/api/v1/history/mrc-daily")
+    : "/api/v1/history/mrc-daily";
+
+function renderMrcDailyChart(records, releases) {
+    const canvas = document.getElementById("mrc-daily-chart");
+    if (!canvas || !window.Chart) return;
+
+    const labels = records.map(r => r.obs_date);
+    const netToResearcher = records.map(r => r.net_to_researcher);
+    const foundationFees  = records.map(r => r.foundation_fees);
+    const stakerFees      = records.map(r => r.staker_fees);
+    const mrcsPaid        = records.map(r => r.mrcs_paid);
+
+    const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
+    const annotations = window.buildChartAnnotations
+        ? window.buildChartAnnotations(labels, releases)
+        : {};
+
+    const chart = new Chart(canvas, {
+        type: "line",
+        data: {
+            labels: labels,
+            datasets: [
+                // Stacked-area: bottom is net-to-researcher (the bulk),
+                // then foundation fees, then staker fees on top. Stack
+                // total = gross MRC research reward for that day.
+                {
+                    label: "Net to researcher",
+                    data: netToResearcher,
+                    borderColor: "#2d6cdf",
+                    backgroundColor: "rgba(45, 108, 223, 0.45)",
+                    yAxisID: "y",
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    fill: true,
+                    stack: "amounts",
+                },
+                {
+                    label: "Foundation fees",
+                    data: foundationFees,
+                    borderColor: "#7e57c2",
+                    backgroundColor: "rgba(126, 87, 194, 0.55)",
+                    yAxisID: "y",
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    fill: true,
+                    stack: "amounts",
+                },
+                {
+                    label: "Staker fees",
+                    data: stakerFees,
+                    borderColor: "#ef6c00",
+                    backgroundColor: "rgba(239, 108, 0, 0.55)",
+                    yAxisID: "y",
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    fill: true,
+                    stack: "amounts",
+                },
+                // Secondary axis: per-day MRC count. Two-decade smaller
+                // than the amounts so it gets its own scale; rendered
+                // as a thin dotted line behind the stacked areas.
+                {
+                    label: "MRCs paid",
+                    data: mrcsPaid,
+                    type: "line",
+                    borderColor: "#d62728",
+                    backgroundColor: "transparent",
+                    yAxisID: "y1",
+                    borderWidth: 1.25,
+                    borderDash: [4, 3],
+                    pointRadius: 0,
+                    tension: 0.2,
+                    fill: false,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: "index", intersect: false },
+            plugins: {
+                title: {
+                    display: true,
+                    text: "Daily MRC payments — net-to-researcher / foundation fees / staker fees (stacked, left); MRCs/day count (right)",
+                },
+                legend: { position: "bottom" },
+                tooltip: { mode: "index", intersect: false },
+                annotation: { annotations },
+            },
+            scales: {
+                x: {
+                    ticks: window.yearlyXTicksConfig
+                        ? window.yearlyXTicksConfig(labels)
+                        : { maxTicksLimit: 12, autoSkip: true },
+                    title: { display: true, text: "Date" },
+                    grid: grid.xGrid,
+                },
+                y: {
+                    stacked: true,
+                    beginAtZero: true,
+                    position: "left",
+                    title: { display: true, text: "GRC paid via MRC" },
+                    grid: grid.yGrid,
+                },
+                y1: {
+                    beginAtZero: true,
+                    position: "right",
+                    title: { display: true, text: "MRCs / day (count)" },
+                    grid: { drawOnChartArea: false },
+                    ticks: { stepSize: 1 },
+                },
+            },
+        },
+    });
+    if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
+}
+
+function initMrcDaily() {
+    const canvas = document.getElementById("mrc-daily-chart");
+    if (!canvas) return;
+
+    Promise.all([
+        fetch(MRC_API_URL).then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        }),
+        window.analyticsReleasesPromise || Promise.resolve([]),
+    ])
+        .then(([payload, releases]) => {
+            if (!payload || !Array.isArray(payload.data)) {
+                throw new Error("Unexpected API payload");
+            }
+            renderMrcDailyChart(payload.data, releases || []);
+        })
+        .catch(err => {
+            console.error("Failed to load mrc-daily:", err);
+            if (window.analyticsError) {
+                window.analyticsError("Couldn't load MRC payment data.");
+            }
+        });
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initMrcDaily);
+} else {
+    initMrcDaily();
+}

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -18,36 +18,40 @@ const MRC_API_URL = window.analyticsApi
     ? window.analyticsApi("/api/v1/history/mrc-daily")
     : "/api/v1/history/mrc-daily";
 
-// Rolling-mean window. Trailing (each point is the average of the
-// preceding `MA_WINDOW` days including itself), so the right edge is
-// "honest" rather than running ahead in time. The first MA_WINDOW-1
-// days are computed over the available history (a partial window) so
-// the series starts at the data's start rather than `MA_WINDOW` days
-// later — visually cleaner and the partial-window distortion is small
-// against the noise we're trying to suppress.
-const MA_WINDOW = 7;
+// Centered 14-day moving average. Each point is the mean of a
+// 14-day window centered (as nearly as the even width allows) on the
+// point: 7 days before through 6 days after, inclusive. Centered
+// rather than trailing for better visual smoothness; the trade-off
+// is that the rightmost ~6 days fall in a partial window and so are
+// noisier than the bulk of the series. Edge points (both ends) use
+// whatever portion of the window is available.
+const MA_WINDOW = 14;
+const MA_HALF_BEFORE = MA_WINDOW / 2;          // 7
+const MA_HALF_AFTER  = MA_WINDOW - MA_HALF_BEFORE - 1;  // 6
 
-function rollingMean(arr, window) {
+function rollingMean(arr, halfBefore, halfAfter) {
     const out = new Array(arr.length);
-    let sum = 0;
     for (let i = 0; i < arr.length; i++) {
-        sum += arr[i];
-        if (i >= window) sum -= arr[i - window];
-        const denom = Math.min(i + 1, window);
-        out[i] = sum / denom;
+        const lo = Math.max(0, i - halfBefore);
+        const hi = Math.min(arr.length - 1, i + halfAfter);
+        let sum = 0;
+        for (let j = lo; j <= hi; j++) sum += arr[j];
+        out[i] = sum / (hi - lo + 1);
     }
     return out;
 }
+
+const MA_SUFFIX = " (14d MA)";
 
 function renderMrcDailyChart(records, releases) {
     const canvas = document.getElementById("mrc-daily-chart");
     if (!canvas || !window.Chart) return;
 
     const labels = records.map(r => r.obs_date);
-    const netToResearcher = rollingMean(records.map(r => r.net_to_researcher), MA_WINDOW);
-    const foundationFees  = rollingMean(records.map(r => r.foundation_fees),   MA_WINDOW);
-    const stakerFees      = rollingMean(records.map(r => r.staker_fees),       MA_WINDOW);
-    const mrcsPaid        = rollingMean(records.map(r => r.mrcs_paid),         MA_WINDOW);
+    const netToResearcher = rollingMean(records.map(r => r.net_to_researcher), MA_HALF_BEFORE, MA_HALF_AFTER);
+    const foundationFees  = rollingMean(records.map(r => r.foundation_fees),   MA_HALF_BEFORE, MA_HALF_AFTER);
+    const stakerFees      = rollingMean(records.map(r => r.staker_fees),       MA_HALF_BEFORE, MA_HALF_AFTER);
+    const mrcsPaid        = rollingMean(records.map(r => r.mrcs_paid),         MA_HALF_BEFORE, MA_HALF_AFTER);
 
     const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
     const annotations = window.buildChartAnnotations
@@ -63,7 +67,7 @@ function renderMrcDailyChart(records, releases) {
                 // then foundation fees, then staker fees on top. Stack
                 // total = gross MRC research reward for that day.
                 {
-                    label: "Net to researcher",
+                    label: "Net to researcher" + MA_SUFFIX,
                     data: netToResearcher,
                     borderColor: "#2d6cdf",
                     backgroundColor: "rgba(45, 108, 223, 0.45)",
@@ -74,7 +78,7 @@ function renderMrcDailyChart(records, releases) {
                     stack: "amounts",
                 },
                 {
-                    label: "Foundation fees",
+                    label: "Foundation fees" + MA_SUFFIX,
                     data: foundationFees,
                     borderColor: "#7e57c2",
                     backgroundColor: "rgba(126, 87, 194, 0.55)",
@@ -85,7 +89,7 @@ function renderMrcDailyChart(records, releases) {
                     stack: "amounts",
                 },
                 {
-                    label: "Staker fees",
+                    label: "Staker fees" + MA_SUFFIX,
                     data: stakerFees,
                     borderColor: "#ef6c00",
                     backgroundColor: "rgba(239, 108, 0, 0.55)",
@@ -99,7 +103,7 @@ function renderMrcDailyChart(records, releases) {
                 // than the amounts so it gets its own scale; rendered
                 // as a thin dotted line behind the stacked areas.
                 {
-                    label: "MRCs paid",
+                    label: "MRCs paid" + MA_SUFFIX,
                     data: mrcsPaid,
                     type: "line",
                     borderColor: "#d62728",
@@ -120,7 +124,7 @@ function renderMrcDailyChart(records, releases) {
             plugins: {
                 title: {
                     display: true,
-                    text: "Daily MRC payments (7-day moving average) — net-to-researcher / foundation fees / staker fees (stacked, left); MRCs/day count (right)",
+                    text: "Daily MRC payments (14-day centered moving average) — net-to-researcher / foundation fees / staker fees (stacked, left); MRCs/day count (right)",
                 },
                 legend: { position: "bottom" },
                 tooltip: { mode: "index", intersect: false },

--- a/assets/js/fetch-mrc-daily.js
+++ b/assets/js/fetch-mrc-daily.js
@@ -18,6 +18,34 @@ const MRC_API_URL = window.analyticsApi
     ? window.analyticsApi("/api/v1/history/mrc-daily")
     : "/api/v1/history/mrc-daily";
 
+// We align the MRC chart's x-axis to the CPID-activity chart above so
+// that visual correlations between CPID participation and MRC volume
+// are easy to spot. CPID-activity history goes back to 2020-09-09 but
+// MRC support didn't exist before v12 (mainnet block 2 671 700,
+// 2022-08-28), so the leading portion of the MRC series is zeros by
+// construction. Sourcing the date axis from cpid-churn — rather than
+// hardcoding a start date — keeps the two charts in lockstep if the
+// underlying ConvergedStats history is ever extended.
+const CPID_CHURN_API_URL = window.analyticsApi
+    ? window.analyticsApi("/api/v1/history/cpid-churn")
+    : "/api/v1/history/cpid-churn";
+
+const MRC_ZERO_RECORD = {
+    mrcs_paid: 0,
+    mrcs_fee_boosted: 0,
+    gross_research: 0,
+    net_to_researcher: 0,
+    foundation_fees: 0,
+    staker_fees: 0,
+    calc_min_fees: 0,
+    fee_boost: 0,
+};
+
+function alignMrcToLabels(mrcRecords, axisLabels) {
+    const byDate = new Map(mrcRecords.map(r => [r.obs_date, r]));
+    return axisLabels.map(date => byDate.get(date) || { obs_date: date, ...MRC_ZERO_RECORD });
+}
+
 // Centered 14-day moving average. Each point is the mean of a
 // 14-day window centered (as nearly as the even width allows) on the
 // point: 7 days before through 6 days after, inclusive. Centered
@@ -167,13 +195,22 @@ function initMrcDaily() {
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             return r.json();
         }),
+        fetch(CPID_CHURN_API_URL).then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        }),
         window.analyticsReleasesPromise || Promise.resolve([]),
     ])
-        .then(([payload, releases]) => {
-            if (!payload || !Array.isArray(payload.data)) {
-                throw new Error("Unexpected API payload");
+        .then(([mrcPayload, cpidPayload, releases]) => {
+            if (!mrcPayload || !Array.isArray(mrcPayload.data)) {
+                throw new Error("Unexpected mrc-daily payload");
             }
-            renderMrcDailyChart(payload.data, releases || []);
+            if (!cpidPayload || !Array.isArray(cpidPayload.data)) {
+                throw new Error("Unexpected cpid-churn payload");
+            }
+            const axisLabels = cpidPayload.data.map(r => r.obs_date);
+            const aligned = alignMrcToLabels(mrcPayload.data, axisLabels);
+            renderMrcDailyChart(aligned, releases || []);
         })
         .catch(err => {
             console.error("Failed to load mrc-daily:", err);

--- a/assets/js/fetch-project-active-cpids.js
+++ b/assets/js/fetch-project-active-cpids.js
@@ -1,0 +1,92 @@
+/**
+ * fetch-project-active-cpids.js — multi-line chart, one line per project,
+ * showing daily distinct active-CPID count on that project.
+ */
+
+function hslColor(i, total) {
+    // Evenly spread hues around the wheel; keep saturation/lightness constant
+    // so adjacent lines contrast clearly.
+    const h = Math.round((360 * i) / Math.max(total, 1));
+    return `hsl(${h}, 65%, 48%)`;
+}
+
+function buildPerProjectSeries(records) {
+    // Pivot the flat (date, project, count) list into {dates, series-per-project}.
+    const dateSet = new Set();
+    const perProject = new Map();
+    for (const r of records) {
+        dateSet.add(r.obs_date);
+        if (!perProject.has(r.project)) perProject.set(r.project, new Map());
+        perProject.get(r.project).set(r.obs_date, r.active_cpids);
+    }
+    const dates = Array.from(dateSet).sort();
+    const projects = Array.from(perProject.keys()).sort();
+    const datasets = projects.map((p, i) => ({
+        label: p,
+        data: dates.map(d => perProject.get(p).get(d) ?? null),
+        borderColor: hslColor(i, projects.length),
+        backgroundColor: hslColor(i, projects.length),
+        borderWidth: 1.25,
+        pointRadius: 0,
+        tension: 0.2,
+        spanGaps: false,
+    }));
+    return { labels: dates, datasets };
+}
+
+function initProjectActiveCpids() {
+    const canvas = document.getElementById("project-active-cpids-chart");
+    if (!canvas) return;
+
+    fetch(window.analyticsApi("/api/v1/history/project-active-cpids"))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            if (!payload || !Array.isArray(payload.data)) {
+                throw new Error("Unexpected payload");
+            }
+            const { labels, datasets } = buildPerProjectSeries(payload.data);
+            new Chart(canvas, {
+                type: "line",
+                data: { labels, datasets },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: "index", intersect: false },
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: "Active CPIDs by project",
+                        },
+                        legend: {
+                            position: "bottom",
+                            labels: { boxWidth: 12, padding: 8 },
+                        },
+                        tooltip: { mode: "index", intersect: false },
+                    },
+                    scales: {
+                        x: {
+                            ticks: { maxTicksLimit: 12, autoSkip: true },
+                            title: { display: true, text: "Date" },
+                        },
+                        y: {
+                            beginAtZero: true,
+                            title: { display: true, text: "Active CPIDs (mag > 0)" },
+                        },
+                    },
+                },
+            });
+        })
+        .catch(err => {
+            console.error("Failed to load project-active-cpids:", err);
+            window.analyticsError("Couldn't load per-project activity data.");
+        });
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initProjectActiveCpids);
+} else {
+    initProjectActiveCpids();
+}

--- a/assets/js/fetch-project-active-cpids.js
+++ b/assets/js/fetch-project-active-cpids.js
@@ -90,7 +90,6 @@ function initProjectActiveCpids() {
                     },
                 },
             });
-            if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
         })
         .catch(err => {
             console.error("Failed to load project-active-cpids:", err);

--- a/assets/js/fetch-project-active-cpids.js
+++ b/assets/js/fetch-project-active-cpids.js
@@ -44,15 +44,16 @@ function initProjectActiveCpids() {
             return r.json();
         }),
         window.analyticsReleasesPromise || Promise.resolve([]),
+        window.analyticsBlockVersionsPromise || Promise.resolve([]),
     ])
-        .then(([payload, releases]) => {
+        .then(([payload, releases, activations]) => {
             if (!payload || !Array.isArray(payload.data)) {
                 throw new Error("Unexpected payload");
             }
             const { labels, datasets } = buildPerProjectSeries(payload.data);
             const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
             const annotations = window.buildChartAnnotations
-                ? window.buildChartAnnotations(labels, releases)
+                ? window.buildChartAnnotations(labels, releases, activations)
                 : {};
             const chart = new Chart(canvas, {
                 type: "line",

--- a/assets/js/fetch-project-active-cpids.js
+++ b/assets/js/fetch-project-active-cpids.js
@@ -38,17 +38,23 @@ function initProjectActiveCpids() {
     const canvas = document.getElementById("project-active-cpids-chart");
     if (!canvas) return;
 
-    fetch(window.analyticsApi("/api/v1/history/project-active-cpids"))
-        .then(r => {
+    Promise.all([
+        fetch(window.analyticsApi("/api/v1/history/project-active-cpids")).then(r => {
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             return r.json();
-        })
-        .then(payload => {
+        }),
+        window.analyticsReleasesPromise || Promise.resolve([]),
+    ])
+        .then(([payload, releases]) => {
             if (!payload || !Array.isArray(payload.data)) {
                 throw new Error("Unexpected payload");
             }
             const { labels, datasets } = buildPerProjectSeries(payload.data);
-            new Chart(canvas, {
+            const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
+            const annotations = window.buildChartAnnotations
+                ? window.buildChartAnnotations(labels, releases)
+                : {};
+            const chart = new Chart(canvas, {
                 type: "line",
                 data: { labels, datasets },
                 options: {
@@ -65,19 +71,25 @@ function initProjectActiveCpids() {
                             labels: { boxWidth: 12, padding: 8 },
                         },
                         tooltip: { mode: "index", intersect: false },
+                        annotation: { annotations },
                     },
                     scales: {
                         x: {
-                            ticks: { maxTicksLimit: 12, autoSkip: true },
+                            ticks: window.yearlyXTicksConfig
+                                ? window.yearlyXTicksConfig(labels)
+                                : { maxTicksLimit: 12, autoSkip: true },
                             title: { display: true, text: "Date" },
+                            grid: grid.xGrid,
                         },
                         y: {
                             beginAtZero: true,
                             title: { display: true, text: "Active CPIDs (mag > 0)" },
+                            grid: grid.yGrid,
                         },
                     },
                 },
             });
+            if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
         })
         .catch(err => {
             console.error("Failed to load project-active-cpids:", err);

--- a/assets/js/fetch-project-churn.js
+++ b/assets/js/fetch-project-churn.js
@@ -1,0 +1,99 @@
+/**
+ * fetch-project-churn.js — mixed chart of daily project count in the
+ * superblock (line, left axis) plus in/out bars (right axis).
+ */
+
+function initProjectChurn() {
+    const canvas = document.getElementById("project-churn-chart");
+    if (!canvas) return;
+
+    fetch(window.analyticsApi("/api/v1/history/project-churn"))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            const rows = payload.data || [];
+            const labels    = rows.map(r => r.obs_date);
+            const total     = rows.map(r => r.total_projects);
+            const inCount   = rows.map(r => r.projects_in);
+            const outCount  = rows.map(r => r.projects_out);
+
+            new Chart(canvas, {
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            type: "line",
+                            label: "Projects in superblock",
+                            data: total,
+                            borderColor: "#2d6cdf",
+                            backgroundColor: "rgba(45, 108, 223, 0.1)",
+                            yAxisID: "y",
+                            borderWidth: 1.5,
+                            pointRadius: 0,
+                            tension: 0.2,
+                            fill: true,
+                        },
+                        {
+                            type: "bar",
+                            label: "Projects added",
+                            data: inCount,
+                            backgroundColor: "#2ca02c",
+                            yAxisID: "y1",
+                            barThickness: 2,
+                        },
+                        {
+                            type: "bar",
+                            label: "Projects dropped",
+                            data: outCount,
+                            backgroundColor: "#d62728",
+                            yAxisID: "y1",
+                            barThickness: 2,
+                        },
+                    ],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: "index", intersect: false },
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: "Projects in superblock (left) and daily adds/drops (right)",
+                        },
+                        legend: { position: "bottom" },
+                        tooltip: { mode: "index", intersect: false },
+                    },
+                    scales: {
+                        x: {
+                            ticks: { maxTicksLimit: 12, autoSkip: true },
+                            title: { display: true, text: "Date" },
+                        },
+                        y: {
+                            beginAtZero: false,
+                            position: "left",
+                            title: { display: true, text: "Projects" },
+                        },
+                        y1: {
+                            beginAtZero: true,
+                            position: "right",
+                            title: { display: true, text: "Adds / drops / day" },
+                            grid: { drawOnChartArea: false },
+                            ticks: { stepSize: 1 },
+                        },
+                    },
+                },
+            });
+        })
+        .catch(err => {
+            console.error("Failed to load project-churn:", err);
+            window.analyticsError("Couldn't load project churn data.");
+        });
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initProjectChurn);
+} else {
+    initProjectChurn();
+}

--- a/assets/js/fetch-project-churn.js
+++ b/assets/js/fetch-project-churn.js
@@ -13,8 +13,9 @@ function initProjectChurn() {
             return r.json();
         }),
         window.analyticsReleasesPromise || Promise.resolve([]),
+        window.analyticsBlockVersionsPromise || Promise.resolve([]),
     ])
-        .then(([payload, releases]) => {
+        .then(([payload, releases, activations]) => {
             const rows = payload.data || [];
             const labels    = rows.map(r => r.obs_date);
             const total     = rows.map(r => r.total_projects);
@@ -23,7 +24,7 @@ function initProjectChurn() {
 
             const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
             const annotations = window.buildChartAnnotations
-                ? window.buildChartAnnotations(labels, releases)
+                ? window.buildChartAnnotations(labels, releases, activations)
                 : {};
 
             const chart = new Chart(canvas, {

--- a/assets/js/fetch-project-churn.js
+++ b/assets/js/fetch-project-churn.js
@@ -83,7 +83,7 @@ function initProjectChurn() {
                             grid: grid.xGrid,
                         },
                         y: {
-                            beginAtZero: false,
+                            beginAtZero: true,
                             position: "left",
                             title: { display: true, text: "Projects" },
                             grid: grid.yGrid,

--- a/assets/js/fetch-project-churn.js
+++ b/assets/js/fetch-project-churn.js
@@ -98,7 +98,6 @@ function initProjectChurn() {
                     },
                 },
             });
-            if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
         })
         .catch(err => {
             console.error("Failed to load project-churn:", err);

--- a/assets/js/fetch-project-churn.js
+++ b/assets/js/fetch-project-churn.js
@@ -7,19 +7,26 @@ function initProjectChurn() {
     const canvas = document.getElementById("project-churn-chart");
     if (!canvas) return;
 
-    fetch(window.analyticsApi("/api/v1/history/project-churn"))
-        .then(r => {
+    Promise.all([
+        fetch(window.analyticsApi("/api/v1/history/project-churn")).then(r => {
             if (!r.ok) throw new Error(`HTTP ${r.status}`);
             return r.json();
-        })
-        .then(payload => {
+        }),
+        window.analyticsReleasesPromise || Promise.resolve([]),
+    ])
+        .then(([payload, releases]) => {
             const rows = payload.data || [];
             const labels    = rows.map(r => r.obs_date);
             const total     = rows.map(r => r.total_projects);
             const inCount   = rows.map(r => r.projects_in);
             const outCount  = rows.map(r => r.projects_out);
 
-            new Chart(canvas, {
+            const grid = window.softGridStyle ? window.softGridStyle() : { xGrid: {}, yGrid: {} };
+            const annotations = window.buildChartAnnotations
+                ? window.buildChartAnnotations(labels, releases)
+                : {};
+
+            const chart = new Chart(canvas, {
                 data: {
                     labels: labels,
                     datasets: [
@@ -64,16 +71,21 @@ function initProjectChurn() {
                         },
                         legend: { position: "bottom" },
                         tooltip: { mode: "index", intersect: false },
+                        annotation: { annotations },
                     },
                     scales: {
                         x: {
-                            ticks: { maxTicksLimit: 12, autoSkip: true },
+                            ticks: window.yearlyXTicksConfig
+                                ? window.yearlyXTicksConfig(labels)
+                                : { maxTicksLimit: 12, autoSkip: true },
                             title: { display: true, text: "Date" },
+                            grid: grid.xGrid,
                         },
                         y: {
                             beginAtZero: false,
                             position: "left",
                             title: { display: true, text: "Projects" },
+                            grid: grid.yGrid,
                         },
                         y1: {
                             beginAtZero: true,
@@ -85,6 +97,7 @@ function initProjectChurn() {
                     },
                 },
             });
+            if (window.registerAnalyticsChart) window.registerAnalyticsChart(chart);
         })
         .catch(err => {
             console.error("Failed to load project-churn:", err);

--- a/assets/js/fetch-top-cpids.js
+++ b/assets/js/fetch-top-cpids.js
@@ -18,23 +18,50 @@ function shortCpid(hex) {
     return hex.slice(0, 12) + "…";
 }
 
+// Pool badge renderer — small Bootstrap badge linking to the pool's
+// site, shown next to the CPID hex. Empty string for non-pool CPIDs.
+function poolBadge(cpid) {
+    if (!window.POOL_CPIDS) return "";
+    const pool = window.POOL_CPIDS.get(cpid);
+    if (!pool) return "";
+    // Inline-block, ms-2 separates from the CPID code, link opens the
+    // pool's site in a new tab. text-decoration-none keeps it visually
+    // a badge rather than an underlined link.
+    return ` <a href="${pool.url}" target="_blank" rel="noopener"
+               class="badge bg-info text-dark text-decoration-none ms-2"
+               title="Pool — opens ${pool.url}">${pool.name}</a>`;
+}
+
+// Cache the most recent payload so the "Hide pools" toggle can
+// re-render without re-fetching.
+let lastTopCpidsRows = [];
+
 function renderTopCpidsRows(rows) {
+    lastTopCpidsRows = rows || [];
+
     const tbody = document.getElementById("top-cpids-tbody");
     if (!tbody) return;
     tbody.innerHTML = "";
-    rows.forEach((row, i) => {
+
+    const hidePools = !!document.getElementById("top-cpids-hide-pools")?.checked;
+    const filtered = hidePools
+        ? lastTopCpidsRows.filter(r => !window.isPoolCpid(r.cpid))
+        : lastTopCpidsRows;
+
+    filtered.forEach((row, i) => {
         const tr = document.createElement("tr");
         // The CPID cell is rendered as a link styled `<code>` so it's
         // discoverable as clickable. Click drops the full CPID into the
         // sand-chart input below and triggers a render. A descriptive
         // title ("...click to plot below") is appended to the existing
         // tooltip-of-full-CPID so screen readers and hover users see
-        // both the value and the affordance.
+        // both the value and the affordance. For pool CPIDs an inline
+        // badge follows the code, linking to the pool's site.
         tr.innerHTML = `
             <td class="text-muted">${i + 1}</td>
             <td><a href="#cpid-sand-section" class="cpid-link"
                    title="${row.cpid} — click to plot below"
-                   data-cpid="${row.cpid}"><code>${shortCpid(row.cpid)}</code></a></td>
+                   data-cpid="${row.cpid}"><code>${shortCpid(row.cpid)}</code></a>${poolBadge(row.cpid)}</td>
             <td class="text-end">${formatNumber(row.days_active, 0)}</td>
             <td class="text-end">${formatNumber(row.lifetime_mag_sum, 2)}</td>
             <td class="text-end">${formatNumber(row.lifetime_mag_avg_active, 2)}</td>
@@ -151,6 +178,13 @@ function initTopCpids() {
 
     if (projectSel) projectSel.addEventListener("change", loadTopCpids);
     if (limitSel)   limitSel.addEventListener("change", loadTopCpids);
+
+    // The hide-pools toggle re-renders from cached rows without
+    // re-fetching — the filter is purely client-side.
+    const hidePools = document.getElementById("top-cpids-hide-pools");
+    if (hidePools) {
+        hidePools.addEventListener("change", () => renderTopCpidsRows(lastTopCpidsRows));
+    }
 
     document.querySelectorAll(".top-cpids-sort").forEach(th => {
         th.style.cursor = "pointer";

--- a/assets/js/fetch-top-cpids.js
+++ b/assets/js/fetch-top-cpids.js
@@ -116,6 +116,32 @@ function updateSortIndicators() {
     });
 }
 
+// Build the period/custom-range query-string fragment. Returns "" on
+// invalid custom selection (and surfaces a status message via
+// analyticsError) so the caller can short-circuit.
+function topCpidsPeriodParams() {
+    const periodSel = document.getElementById("top-cpids-period");
+    const period = periodSel ? periodSel.value : "all";
+
+    if (period === "custom") {
+        const startEl = document.getElementById("top-cpids-start-date");
+        const endEl   = document.getElementById("top-cpids-end-date");
+        const start = startEl ? startEl.value : "";
+        const end   = endEl   ? endEl.value   : "";
+        if (!start || !end) {
+            return { ok: false, msg: "Pick both a start and end date." };
+        }
+        if (start > end) {
+            return { ok: false, msg: "Start date must be on or before end date." };
+        }
+        return { ok: true, qs: `&start_date=${start}&end_date=${end}` };
+    }
+
+    // "all" / "week" / "month" / "quarter" / "year" — pass period
+    // through (backend treats period=all the same as omitting it).
+    return { ok: true, qs: `&period=${encodeURIComponent(period)}` };
+}
+
 function loadTopCpids() {
     const projectSel = document.getElementById("top-cpids-project");
     const limitSel   = document.getElementById("top-cpids-limit");
@@ -124,9 +150,16 @@ function loadTopCpids() {
     const project = projectSel ? projectSel.value : "";
     const limit   = limitSel   ? limitSel.value   : "100";
 
+    const periodParams = topCpidsPeriodParams();
+    if (!periodParams.ok) {
+        window.analyticsError(periodParams.msg);
+        return;
+    }
+
     let url = `/api/v1/history/top-cpids`
         + `?limit=${encodeURIComponent(limit)}`
-        + `&order_by=${encodeURIComponent(topCpidsOrderBy)}`;
+        + `&order_by=${encodeURIComponent(topCpidsOrderBy)}`
+        + periodParams.qs;
     if (project) url += `&project=${encodeURIComponent(project)}`;
 
     updateSortIndicators();
@@ -175,9 +208,38 @@ function populateProjectDropdown() {
 function initTopCpids() {
     const projectSel = document.getElementById("top-cpids-project");
     const limitSel   = document.getElementById("top-cpids-limit");
+    const periodSel  = document.getElementById("top-cpids-period");
 
     if (projectSel) projectSel.addEventListener("change", loadTopCpids);
     if (limitSel)   limitSel.addEventListener("change", loadTopCpids);
+
+    // Period selector — show/hide the custom-range inputs and reload.
+    // For canned periods we reload immediately on change. For custom
+    // we wait for the Apply button so the user can fill both dates
+    // before firing a request.
+    const customRangeEls = document.querySelectorAll(".top-cpids-custom-range");
+    const showCustomRange = (show) => {
+        customRangeEls.forEach(el => { el.style.display = show ? "" : "none"; });
+    };
+    if (periodSel) {
+        periodSel.addEventListener("change", () => {
+            const isCustom = periodSel.value === "custom";
+            showCustomRange(isCustom);
+            if (!isCustom) loadTopCpids();
+        });
+    }
+    const applyBtn = document.getElementById("top-cpids-apply-range");
+    if (applyBtn) applyBtn.addEventListener("click", loadTopCpids);
+
+    // Pre-fill the custom date inputs with a sensible default (last
+    // year ending today) so the picker isn't empty when first opened.
+    const today = new Date();
+    const yearAgo = new Date(today.getTime() - 365 * 86400 * 1000);
+    const fmt = (d) => d.toISOString().slice(0, 10);
+    const startEl = document.getElementById("top-cpids-start-date");
+    const endEl   = document.getElementById("top-cpids-end-date");
+    if (startEl && !startEl.value) startEl.value = fmt(yearAgo);
+    if (endEl   && !endEl.value)   endEl.value   = fmt(today);
 
     // The hide-pools toggle re-renders from cached rows without
     // re-fetching — the filter is purely client-side.

--- a/assets/js/fetch-top-cpids.js
+++ b/assets/js/fetch-top-cpids.js
@@ -1,0 +1,140 @@
+/**
+ * fetch-top-cpids.js — populate the top-CPIDs table and its project
+ * filter dropdown. The dropdown is driven by /api/v1/history/projects;
+ * choosing a project switches the query to the per-project leaderboard.
+ */
+
+function formatNumber(n, decimals) {
+    if (n === undefined || n === null) return "—";
+    const d = decimals === undefined ? 2 : decimals;
+    return Number(n).toLocaleString(undefined, {
+        minimumFractionDigits: d,
+        maximumFractionDigits: d,
+    });
+}
+
+function shortCpid(hex) {
+    if (!hex) return "";
+    return hex.slice(0, 12) + "…";
+}
+
+function renderTopCpidsRows(rows) {
+    const tbody = document.getElementById("top-cpids-tbody");
+    if (!tbody) return;
+    tbody.innerHTML = "";
+    rows.forEach((row, i) => {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+            <td class="text-muted">${i + 1}</td>
+            <td><code title="${row.cpid}">${shortCpid(row.cpid)}</code></td>
+            <td class="text-end">${formatNumber(row.days_active, 0)}</td>
+            <td class="text-end">${formatNumber(row.lifetime_mag_sum, 2)}</td>
+            <td class="text-end">${formatNumber(row.lifetime_mag_avg_active, 2)}</td>
+            <td class="text-end">${formatNumber(row.lifetime_mag_avg_elapsed, 2)}</td>
+            <td>${row.first_seen || ""}</td>
+            <td>${row.last_seen || ""}</td>
+        `;
+        tbody.appendChild(tr);
+    });
+}
+
+// Current sort key — kept in closure so header-click handlers and
+// dropdown handlers refer to the same state.
+let topCpidsOrderBy = "lifetime_mag_sum";
+
+function updateSortIndicators() {
+    document.querySelectorAll(".top-cpids-sort").forEach(th => {
+        const key = th.dataset.order;
+        const arrow = th.querySelector(".sort-arrow");
+        if (arrow) arrow.remove();
+        if (key === topCpidsOrderBy) {
+            const span = document.createElement("span");
+            span.className = "sort-arrow ms-1";
+            span.textContent = "▼";
+            th.appendChild(span);
+        }
+    });
+}
+
+function loadTopCpids() {
+    const projectSel = document.getElementById("top-cpids-project");
+    const limitSel   = document.getElementById("top-cpids-limit");
+    const loading    = document.getElementById("top-cpids-loading");
+
+    const project = projectSel ? projectSel.value : "";
+    const limit   = limitSel   ? limitSel.value   : "100";
+
+    let url = `/api/v1/history/top-cpids`
+        + `?limit=${encodeURIComponent(limit)}`
+        + `&order_by=${encodeURIComponent(topCpidsOrderBy)}`;
+    if (project) url += `&project=${encodeURIComponent(project)}`;
+
+    updateSortIndicators();
+    if (loading) loading.style.display = "";
+    fetch(window.analyticsApi(url))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            const rows = payload.data || [];
+            renderTopCpidsRows(rows);
+        })
+        .catch(err => {
+            console.error("Failed to load top-cpids:", err);
+            window.analyticsError("Couldn't load top researchers.");
+        })
+        .finally(() => {
+            if (loading) loading.style.display = "none";
+        });
+}
+
+function populateProjectDropdown() {
+    const sel = document.getElementById("top-cpids-project");
+    if (!sel) return;
+
+    fetch(window.analyticsApi("/api/v1/history/projects"))
+        .then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        })
+        .then(payload => {
+            const rows = payload.data || [];
+            for (const row of rows) {
+                const opt = document.createElement("option");
+                opt.value = row.name;
+                opt.textContent = row.name;
+                sel.appendChild(opt);
+            }
+        })
+        .catch(err => {
+            console.error("Failed to load project list:", err);
+        });
+}
+
+function initTopCpids() {
+    const projectSel = document.getElementById("top-cpids-project");
+    const limitSel   = document.getElementById("top-cpids-limit");
+
+    if (projectSel) projectSel.addEventListener("change", loadTopCpids);
+    if (limitSel)   limitSel.addEventListener("change", loadTopCpids);
+
+    document.querySelectorAll(".top-cpids-sort").forEach(th => {
+        th.style.cursor = "pointer";
+        th.addEventListener("click", () => {
+            const key = th.dataset.order;
+            if (!key || key === topCpidsOrderBy) return;
+            topCpidsOrderBy = key;
+            loadTopCpids();
+        });
+    });
+
+    populateProjectDropdown();
+    loadTopCpids();
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initTopCpids);
+} else {
+    initTopCpids();
+}

--- a/assets/js/fetch-top-cpids.js
+++ b/assets/js/fetch-top-cpids.js
@@ -18,18 +18,42 @@ function shortCpid(hex) {
     return hex.slice(0, 12) + "…";
 }
 
+// Reject any CPID that isn't 32 hex characters before letting it touch
+// the DOM. Lenient (returns the input as-is for valid hex, "" otherwise)
+// so the row simply omits the badge / data-cpid affordance for malformed
+// values rather than blowing up the whole table.
+function sanitizeCpid(cpid) {
+    return typeof cpid === "string" && /^[0-9a-fA-F]{32}$/.test(cpid) ? cpid : "";
+}
+
+// Allow only http(s) URLs for pool badge links — defensive against
+// `javascript:` etc. if window.POOL_CPIDS is ever sourced from outside
+// the in-page hardcoded list.
+function safePoolUrl(url) {
+    if (typeof url !== "string") return null;
+    return /^https?:\/\//i.test(url.trim()) ? url.trim() : null;
+}
+
 // Pool badge renderer — small Bootstrap badge linking to the pool's
-// site, shown next to the CPID hex. Empty string for non-pool CPIDs.
-function poolBadge(cpid) {
-    if (!window.POOL_CPIDS) return "";
+// site, shown next to the CPID hex. Returns a DOM node or null for
+// non-pool CPIDs (caller appends only when non-null).
+function poolBadgeNode(cpid) {
+    if (!window.POOL_CPIDS) return null;
     const pool = window.POOL_CPIDS.get(cpid);
-    if (!pool) return "";
+    if (!pool) return null;
+    const url = safePoolUrl(pool.url);
+    if (!url) return null;
     // Inline-block, ms-2 separates from the CPID code, link opens the
     // pool's site in a new tab. text-decoration-none keeps it visually
     // a badge rather than an underlined link.
-    return ` <a href="${pool.url}" target="_blank" rel="noopener"
-               class="badge bg-info text-dark text-decoration-none ms-2"
-               title="Pool — opens ${pool.url}">${pool.name}</a>`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.target = "_blank";
+    a.rel = "noopener";
+    a.className = "badge bg-info text-dark text-decoration-none ms-2";
+    a.title = `Pool — opens ${url}`;
+    a.textContent = pool.name || "";
+    return a;
 }
 
 // Cache the most recent payload so the "Hide pools" toggle can
@@ -41,34 +65,68 @@ function renderTopCpidsRows(rows) {
 
     const tbody = document.getElementById("top-cpids-tbody");
     if (!tbody) return;
-    tbody.innerHTML = "";
+    tbody.replaceChildren();
 
     const hidePools = !!document.getElementById("top-cpids-hide-pools")?.checked;
     const filtered = hidePools
         ? lastTopCpidsRows.filter(r => !window.isPoolCpid(r.cpid))
         : lastTopCpidsRows;
 
+    // The CPID cell is rendered as a link styled `<code>` so it's
+    // discoverable as clickable. Click drops the full CPID into the
+    // sand-chart input below and triggers a render. A descriptive
+    // title ("...click to plot below") is appended to the existing
+    // tooltip-of-full-CPID so screen readers and hover users see both
+    // the value and the affordance. For pool CPIDs an inline badge
+    // follows the code, linking to the pool's site. Every API field
+    // goes through textContent or a sanitizing helper before reaching
+    // the DOM (no innerHTML on row HTML).
     filtered.forEach((row, i) => {
         const tr = document.createElement("tr");
-        // The CPID cell is rendered as a link styled `<code>` so it's
-        // discoverable as clickable. Click drops the full CPID into the
-        // sand-chart input below and triggers a render. A descriptive
-        // title ("...click to plot below") is appended to the existing
-        // tooltip-of-full-CPID so screen readers and hover users see
-        // both the value and the affordance. For pool CPIDs an inline
-        // badge follows the code, linking to the pool's site.
-        tr.innerHTML = `
-            <td class="text-muted">${i + 1}</td>
-            <td><a href="#cpid-sand-section" class="cpid-link"
-                   title="${row.cpid} — click to plot below"
-                   data-cpid="${row.cpid}"><code>${shortCpid(row.cpid)}</code></a>${poolBadge(row.cpid)}</td>
-            <td class="text-end">${formatNumber(row.days_active, 0)}</td>
-            <td class="text-end">${formatNumber(row.lifetime_mag_sum, 2)}</td>
-            <td class="text-end">${formatNumber(row.lifetime_mag_avg_active, 2)}</td>
-            <td class="text-end">${formatNumber(row.lifetime_mag_avg_elapsed, 2)}</td>
-            <td>${row.first_seen || ""}</td>
-            <td>${row.last_seen || ""}</td>
-        `;
+        const cpid = sanitizeCpid(row.cpid);
+
+        const idxCell = document.createElement("td");
+        idxCell.className = "text-muted";
+        idxCell.textContent = String(i + 1);
+        tr.appendChild(idxCell);
+
+        const cpidCell = document.createElement("td");
+        if (cpid) {
+            const link = document.createElement("a");
+            link.href = "#cpid-sand-section";
+            link.className = "cpid-link";
+            link.title = `${cpid} — click to plot below`;
+            link.dataset.cpid = cpid;
+            const code = document.createElement("code");
+            code.textContent = shortCpid(cpid);
+            link.appendChild(code);
+            cpidCell.appendChild(link);
+            const badge = poolBadgeNode(cpid);
+            if (badge) {
+                cpidCell.appendChild(document.createTextNode(" "));
+                cpidCell.appendChild(badge);
+            }
+        }
+        tr.appendChild(cpidCell);
+
+        const numCell = (text) => {
+            const td = document.createElement("td");
+            td.className = "text-end";
+            td.textContent = text;
+            return td;
+        };
+        tr.appendChild(numCell(formatNumber(row.days_active, 0)));
+        tr.appendChild(numCell(formatNumber(row.lifetime_mag_sum, 2)));
+        tr.appendChild(numCell(formatNumber(row.lifetime_mag_avg_active, 2)));
+        tr.appendChild(numCell(formatNumber(row.lifetime_mag_avg_elapsed, 2)));
+
+        const firstCell = document.createElement("td");
+        firstCell.textContent = row.first_seen || "";
+        tr.appendChild(firstCell);
+        const lastCell = document.createElement("td");
+        lastCell.textContent = row.last_seen || "";
+        tr.appendChild(lastCell);
+
         tbody.appendChild(tr);
     });
 }

--- a/assets/js/fetch-top-cpids.js
+++ b/assets/js/fetch-top-cpids.js
@@ -24,9 +24,17 @@ function renderTopCpidsRows(rows) {
     tbody.innerHTML = "";
     rows.forEach((row, i) => {
         const tr = document.createElement("tr");
+        // The CPID cell is rendered as a link styled `<code>` so it's
+        // discoverable as clickable. Click drops the full CPID into the
+        // sand-chart input below and triggers a render. A descriptive
+        // title ("...click to plot below") is appended to the existing
+        // tooltip-of-full-CPID so screen readers and hover users see
+        // both the value and the affordance.
         tr.innerHTML = `
             <td class="text-muted">${i + 1}</td>
-            <td><code title="${row.cpid}">${shortCpid(row.cpid)}</code></td>
+            <td><a href="#cpid-sand-section" class="cpid-link"
+                   title="${row.cpid} — click to plot below"
+                   data-cpid="${row.cpid}"><code>${shortCpid(row.cpid)}</code></a></td>
             <td class="text-end">${formatNumber(row.days_active, 0)}</td>
             <td class="text-end">${formatNumber(row.lifetime_mag_sum, 2)}</td>
             <td class="text-end">${formatNumber(row.lifetime_mag_avg_active, 2)}</td>
@@ -35,6 +43,31 @@ function renderTopCpidsRows(rows) {
             <td>${row.last_seen || ""}</td>
         `;
         tbody.appendChild(tr);
+    });
+}
+
+// Single delegated click handler on the tbody — survives table re-renders
+// without re-binding per-row, and only attaches once.
+function wireCpidClickToSandChart() {
+    const tbody = document.getElementById("top-cpids-tbody");
+    if (!tbody || tbody.dataset.cpidClickWired) return;
+    tbody.dataset.cpidClickWired = "1";
+    tbody.addEventListener("click", function(ev) {
+        const link = ev.target.closest("a.cpid-link");
+        if (!link) return;
+        const cpid = link.dataset.cpid;
+        if (!cpid) return;
+        ev.preventDefault();
+        const sandInput = document.getElementById("cpid-sand-input");
+        if (sandInput) sandInput.value = cpid;
+        if (typeof window.loadSandChart === "function") {
+            window.loadSandChart();
+        }
+        const target = document.getElementById("cpid-sand-section")
+            || document.getElementById("cpid-sand-input");
+        if (target && target.scrollIntoView) {
+            target.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
     });
 }
 
@@ -131,6 +164,7 @@ function initTopCpids() {
 
     populateProjectDropdown();
     loadTopCpids();
+    wireCpidClickToSandChart();
 }
 
 if (document.readyState === "loading") {

--- a/assets/js/fetch-whitelist.js
+++ b/assets/js/fetch-whitelist.js
@@ -6,25 +6,30 @@
  * embedded in the page by Jekyll from _data/whitelist.yml.
  *
  * Falls back to the static table if the API is unreachable.
+ *
+ * The host/port routing logic is shared with the analytics page via
+ * window.analyticsApi() (assets/js/analytics-api.js, loaded ahead of
+ * this script on whitelist.htm).
  */
 
-const API_URL = (function() {
-    const host = window.location.hostname;
-    const port = window.location.port;
-    // Production: use the dedicated API subdomain.
-    if (host === "gridcoin.us" || host === "www.gridcoin.us") {
-        return "https://api.gridcoin.us/api/v1/network-status";
-    }
-    // Jekyll dev server binds to port 4001 and has no reverse-proxy of
-    // its own — hop sideways to the FastAPI proxy on :5000 of the same
-    // host (proxy CORS must allow the Jekyll origin).
-    if (port === "4001") {
-        return `${window.location.protocol}//${host}:5000/api/v1/network-status`;
-    }
-    // Everything else (Caddy staging on :81, same-origin prod reverse-proxy)
-    // serves the API under the same origin via /api/v1/*.
-    return "/api/v1/network-status";
-})();
+// Local helper so the rest of this file reads naturally; keeps
+// analytics-api.js as the one place those rules live.
+function whitelistApiUrl() {
+    return window.analyticsApi("/api/v1/network-status");
+}
+
+// Allow only http(s) and mailto URLs into href attributes — protects
+// against `javascript:` / `data:` payloads if the API or static data
+// ever returns an unexpected scheme. Returns "#" for anything else
+// (or empty/missing input) so the link is rendered but harmless.
+function safeUrl(url) {
+    if (!url || typeof url !== "string") return "#";
+    const trimmed = url.trim();
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    if (/^mailto:/i.test(trimmed)) return trimmed;
+    if (trimmed.startsWith("/") || trimmed.startsWith("#")) return trimmed;
+    return "#";
+}
 
 /**
  * Format a large number with commas (e.g. 792425874 → "792,425,874").
@@ -96,6 +101,19 @@ function buildStaticLookup() {
     return lookup;
 }
 
+// Build a column cell — <strong>label</strong><br>value — without
+// touching innerHTML on a string assembled from API data.
+function summaryCell(label, value) {
+    const col = document.createElement("div");
+    col.className = "col-6 col-md-3";
+    const strong = document.createElement("strong");
+    strong.textContent = label;
+    col.appendChild(strong);
+    col.appendChild(document.createElement("br"));
+    col.appendChild(document.createTextNode(value));
+    return col;
+}
+
 /**
  * Render the superblock summary header.
  */
@@ -103,24 +121,52 @@ function renderSuperblockHeader(sb, totalWhitelisted) {
     const el = document.getElementById("superblock-info");
     if (!el || !sb) return;
 
-    el.innerHTML = `
-        <div class="row text-center mb-3">
-            <div class="col-6 col-md-3">
-                <strong>Whitelisted Projects</strong><br>${totalWhitelisted} (${sb.total_projects} in superblock)
-            </div>
-            <div class="col-6 col-md-3">
-                <strong>Active Beacons</strong><br>${formatNumber(sb.active_beacons)}
-            </div>
-            <div class="col-6 col-md-3">
-                <strong>Total CPIDs</strong><br>${formatNumber(sb.total_cpids)}
-            </div>
-            <div class="col-6 col-md-3">
-                <strong>Superblock Height</strong><br>${formatNumber(sb.height)}
-            </div>
-        </div>
-        <p class="text-muted text-center mb-0"><small>Last superblock: ${sb.date} | Total magnitude: ${formatNumber(sb.total_magnitude)}</small></p>
-    `;
+    el.replaceChildren();
+
+    const row = document.createElement("div");
+    row.className = "row text-center mb-3";
+    row.appendChild(summaryCell(
+        "Whitelisted Projects",
+        `${totalWhitelisted} (${sb.total_projects} in superblock)`,
+    ));
+    row.appendChild(summaryCell("Active Beacons", formatNumber(sb.active_beacons)));
+    row.appendChild(summaryCell("Total CPIDs",   formatNumber(sb.total_cpids)));
+    row.appendChild(summaryCell("Superblock Height", formatNumber(sb.height)));
+    el.appendChild(row);
+
+    const p = document.createElement("p");
+    p.className = "text-muted text-center mb-0";
+    const small = document.createElement("small");
+    small.textContent = `Last superblock: ${sb.date} | Total magnitude: ${formatNumber(sb.total_magnitude)}`;
+    p.appendChild(small);
+    el.appendChild(p);
+
     el.style.display = "";
+}
+
+// Tiny helpers to keep renderProjectTable readable while staying off
+// innerHTML for any field that could carry API content.
+function makeCell(opts) {
+    const td = document.createElement("td");
+    if (opts && opts.cls) td.className = opts.cls;
+    if (opts && opts.text !== undefined) td.textContent = opts.text;
+    return td;
+}
+
+function makeLink(href, text, title) {
+    const a = document.createElement("a");
+    a.href = safeUrl(href);
+    a.textContent = text;
+    if (title) a.title = title;
+    return a;
+}
+
+function vendorBadgeImg(src, height) {
+    const img = document.createElement("img");
+    img.src = src;
+    img.height = height;
+    img.alt = "";
+    return img;
 }
 
 /**
@@ -130,7 +176,9 @@ function renderProjectTable(apiProjects, staticLookup) {
     const tbody = document.getElementById("project-table-body");
     if (!tbody) return;
 
-    // Sort projects: active first, then greylisted, then excluded.
+    // Sort projects: Active first, then Excluded (less severe — project
+    // is whitelisted but its stats are stale), then Greylisted (most
+    // severe — not earning rewards). Anything else falls to the bottom.
     const sortOrder = { "Active": 0, "Excluded": 1, "Greylisted": 2 };
     const entries = Object.entries(apiProjects).sort((a, b) => {
         const sa = projectStatus(a[1]).text;
@@ -140,82 +188,124 @@ function renderProjectTable(apiProjects, staticLookup) {
         return a[0].localeCompare(b[0]);
     });
 
-    let html = "";
+    tbody.replaceChildren();
+
     for (const [name, proj] of entries) {
         const status = projectStatus(proj);
         const staticKey = normalizeProjectName(name);
         const staticData = staticLookup[staticKey] || {};
 
         const displayName = proj.display_name || staticData.name || name;
-        const projectUrl = staticData.link || proj.display_url || "#";
-        const goal = staticData.goal || "";
-        const sponsor = staticData.sponsor || "";
+        const projectUrl  = staticData.link || proj.display_url || "#";
+        const goal        = staticData.goal    || "";
+        const sponsor     = staticData.sponsor || "";
 
-        // CPU column — green fill for yes, red for no
+        const tr = document.createElement("tr");
+        if (status.cssClass) tr.className = status.cssClass;
+
+        // Project cell: <a>name</a> [<br><span>(status)</span>]
+        const nameCell = document.createElement("td");
+        nameCell.appendChild(makeLink(projectUrl, displayName));
+        if (status.text !== "Active") {
+            nameCell.appendChild(document.createElement("br"));
+            const span = document.createElement("span");
+            if (status.cssClass) span.className = status.cssClass;
+            span.textContent = `(${status.text})`;
+            nameCell.appendChild(span);
+        }
+        tr.appendChild(nameCell);
+
+        tr.appendChild(makeCell({ cls: "d-none d-lg-table-cell", text: goal }));
+        tr.appendChild(makeCell({ cls: "d-none d-lg-table-cell", text: sponsor }));
+
+        // Status badge.
+        const statusCell = document.createElement("td");
+        const badge = document.createElement("span");
+        const badgeColor = status.text === "Active" ? "success"
+                         : status.text === "Excluded" ? "warning"
+                         : "danger";
+        badge.className = `badge bg-${badgeColor}`;
+        badge.textContent = status.text;
+        statusCell.appendChild(badge);
+        tr.appendChild(statusCell);
+
+        tr.appendChild(makeCell({ cls: "text-end", text: formatCompact(proj.rac) }));
+        tr.appendChild(makeCell({
+            cls: "text-end d-none d-md-table-cell",
+            text: formatCompact(proj.total_credit),
+        }));
+        tr.appendChild(makeCell({
+            cls: "text-end d-none d-md-table-cell",
+            text: proj.cpid_count !== undefined ? formatNumber(proj.cpid_count) : "—",
+        }));
+
+        // CPU column — green fill for yes, red for no.
         const hasCpu = staticData.cpu === "yes";
-        const cpuCell = hasCpu ? "✔️" : "❌";
-        const cpuClass = hasCpu ? "table-color-yes" : "table-color-no";
+        tr.appendChild(makeCell({
+            cls: `${hasCpu ? "table-color-yes" : "table-color-no"} d-none d-lg-table-cell`,
+            text: hasCpu ? "✔️" : "❌",
+        }));
 
-        // GPU column — vendor badges or red X
+        // GPU column — vendor badges or red X.
         const hasGpu = staticData.gpu !== "no" && (
             staticData.nvidia === "yes" || staticData.amd === "yes" || staticData.intel === "yes"
         );
-        let gpuCell = "";
-        if (staticData.nvidia === "yes") gpuCell += '<img src="/assets/img/nvidia_badge.png" height="40"> ';
-        if (staticData.amd === "yes") gpuCell += '<img src="/assets/img/amd_badge.png" height="50"> ';
-        if (staticData.intel === "yes") gpuCell += '<img src="/assets/img/intel_badge.png" height="40"> ';
-        if (!gpuCell) gpuCell = "❌";
-        const gpuClass = hasGpu ? "table-color-yes" : "table-color-no";
+        const gpuCell = document.createElement("td");
+        gpuCell.className = `${hasGpu ? "table-color-yes" : "table-color-no"} d-none d-lg-table-cell`;
+        if (hasGpu) {
+            if (staticData.nvidia === "yes") gpuCell.appendChild(vendorBadgeImg("/assets/img/nvidia_badge.png", 40));
+            if (staticData.amd    === "yes") gpuCell.appendChild(vendorBadgeImg("/assets/img/amd_badge.png", 50));
+            if (staticData.intel  === "yes") gpuCell.appendChild(vendorBadgeImg("/assets/img/intel_badge.png", 40));
+        } else {
+            gpuCell.textContent = "❌";
+        }
+        tr.appendChild(gpuCell);
 
         // GDPR — driven dynamically from the API's gdpr_controls field,
-        // with static data providing the project-specific enable-steps link.
-        // Falls back to the general GDPR guide if no project-specific link.
+        // with static data providing the project-specific enable-steps
+        // link. Falls back to the general GDPR guide if no project-
+        // specific link.
         const gdprRequired = proj.gdpr_controls === true;
-        let gdprCell = "not required";
-        let gdprClass = "";
+        const gdprCell = document.createElement("td");
+        gdprCell.className = `${gdprRequired ? "table-color-gdpr-yes" : ""} d-none d-xl-table-cell`;
         if (gdprRequired) {
-            const gdprLink = staticData["gdpr-enable-steps"] || "/guides/gdpr-stats-export.htm";
-            gdprCell = `<a href="${gdprLink}">required <span class="oi oi-warning"></span></a>`;
-            gdprClass = "table-color-gdpr-yes";
+            const link = makeLink(
+                staticData["gdpr-enable-steps"] || "/guides/gdpr-stats-export.htm",
+                "required ",
+            );
+            const warn = document.createElement("span");
+            warn.className = "oi oi-warning";
+            link.appendChild(warn);
+            gdprCell.appendChild(link);
+        } else {
+            gdprCell.textContent = "not required";
         }
+        tr.appendChild(gdprCell);
 
-        // Team link
-        const teamLink = staticData.team
-            ? `<a href="${staticData.team}" title="Gridcoin Team">📊</a>`
-            : "";
-
-        // Stats link
-        const statsLink = staticData.stats
-            ? `<a href="${staticData.stats}" title="Project Stats">📈</a>`
-            : (proj.stats_url ? `<a href="${proj.stats_url}" title="Project Stats">📈</a>` : "");
-
-        // Greylist health — ZCD/WAS not available until v13 hardfork activates
-        // autogreylisting. If no projects have greylist data, show N/A.
-        let healthCell = "N/A";
+        // Greylist health — ZCD/WAS not available until v13 hardfork
+        // activates autogreylisting. If no projects have greylist data,
+        // show N/A.
+        let healthText = "N/A";
         if (proj.zcd !== undefined) {
             const wasDisplay = proj.was !== undefined ? proj.was.toFixed(2) : "—";
-            healthCell = `ZCD: ${proj.zcd} / WAS: ${wasDisplay}`;
+            healthText = `ZCD: ${proj.zcd} / WAS: ${wasDisplay}`;
         }
+        tr.appendChild(makeCell({ cls: "d-none d-xl-table-cell", text: healthText }));
 
-        html += `<tr class="${status.cssClass}">
-            <td><a href="${projectUrl}">${displayName}</a>
-                ${status.text !== "Active" ? `<br><span class="${status.cssClass}">(${status.text})</span>` : ""}
-            </td>
-            <td class="d-none d-lg-table-cell">${goal}</td>
-            <td class="d-none d-lg-table-cell">${sponsor}</td>
-            <td><span class="badge bg-${status.text === 'Active' ? 'success' : status.text === 'Excluded' ? 'warning' : 'danger'}">${status.text}</span></td>
-            <td class="text-end">${formatCompact(proj.rac)}</td>
-            <td class="text-end d-none d-md-table-cell">${formatCompact(proj.total_credit)}</td>
-            <td class="text-end d-none d-md-table-cell">${proj.cpid_count !== undefined ? formatNumber(proj.cpid_count) : "—"}</td>
-            <td class="${cpuClass} d-none d-lg-table-cell">${cpuCell}</td>
-            <td class="${gpuClass} d-none d-lg-table-cell">${gpuCell}</td>
-            <td class="${gdprClass} d-none d-xl-table-cell">${gdprCell}</td>
-            <td class="d-none d-xl-table-cell">${healthCell}</td>
-            <td>${teamLink} ${statsLink}</td>
-        </tr>`;
+        // Links: team + stats.
+        const linksCell = document.createElement("td");
+        if (staticData.team) {
+            linksCell.appendChild(makeLink(staticData.team, "📊", "Gridcoin Team"));
+        }
+        const statsHref = staticData.stats || proj.stats_url;
+        if (statsHref) {
+            if (linksCell.childNodes.length) linksCell.appendChild(document.createTextNode(" "));
+            linksCell.appendChild(makeLink(statsHref, "📈", "Project Stats"));
+        }
+        tr.appendChild(linksCell);
+
+        tbody.appendChild(tr);
     }
-
-    tbody.innerHTML = html;
 }
 
 /**
@@ -227,7 +317,7 @@ function initWhitelist() {
     const staticTable = document.getElementById("static-whitelist");
     const apiError = document.getElementById("api-error");
 
-    fetch(API_URL)
+    fetch(whitelistApiUrl())
         .then(response => {
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             return response.json();

--- a/assets/js/fetch-whitelist.js
+++ b/assets/js/fetch-whitelist.js
@@ -1,0 +1,262 @@
+/**
+ * fetch-whitelist.js — Dynamic project whitelist table
+ *
+ * Fetches live network status from the Gridcoin API proxy and merges it
+ * with static project data (descriptions, CPU/GPU support, team links)
+ * embedded in the page by Jekyll from _data/whitelist.yml.
+ *
+ * Falls back to the static table if the API is unreachable.
+ */
+
+const API_URL = (function() {
+    const host = window.location.hostname;
+    const port = window.location.port;
+    // Production: use the dedicated API subdomain.
+    if (host === "gridcoin.us" || host === "www.gridcoin.us") {
+        return "https://api.gridcoin.us/api/v1/network-status";
+    }
+    // Jekyll dev server binds to port 4001 and has no reverse-proxy of
+    // its own — hop sideways to the FastAPI proxy on :5000 of the same
+    // host (proxy CORS must allow the Jekyll origin).
+    if (port === "4001") {
+        return `${window.location.protocol}//${host}:5000/api/v1/network-status`;
+    }
+    // Everything else (Caddy staging on :81, same-origin prod reverse-proxy)
+    // serves the API under the same origin via /api/v1/*.
+    return "/api/v1/network-status";
+})();
+
+/**
+ * Format a large number with commas (e.g. 792425874 → "792,425,874").
+ */
+function formatNumber(n) {
+    if (n === undefined || n === null) return "—";
+    return Number(n).toLocaleString();
+}
+
+/**
+ * Format a large number in a compact form (e.g. 792425874 → "792.4M").
+ */
+function formatCompact(n) {
+    if (n === undefined || n === null) return "—";
+    n = Number(n);
+    if (n >= 1e12) return (n / 1e12).toFixed(1) + "T";
+    if (n >= 1e9)  return (n / 1e9).toFixed(1) + "B";
+    if (n >= 1e6)  return (n / 1e6).toFixed(1) + "M";
+    if (n >= 1e3)  return (n / 1e3).toFixed(1) + "K";
+    return n.toString();
+}
+
+/**
+ * Determine the display status and CSS class for a project.
+ */
+function projectStatus(proj) {
+    const status = proj.status || "Unknown";
+
+    if (status === "Automatically Greylisted" || status === "Manually Greylisted") {
+        return { text: "Greylisted", cssClass: "status-greylisted" };
+    }
+    if (status === "Active" && proj.in_superblock === false) {
+        return { text: "Excluded", cssClass: "status-excluded" };
+    }
+    if (status === "Active") {
+        return { text: "Active", cssClass: "status-active" };
+    }
+    return { text: status, cssClass: "" };
+}
+
+/**
+ * Normalize a project name for matching between the API (e.g. "Amicable_Numbers")
+ * and the static YAML data (e.g. "Amicable Numbers").
+ */
+function normalizeProjectName(name) {
+    return name.toLowerCase().replace(/[\s_@]+/g, "").replace(/-/g, "");
+}
+
+/**
+ * Build a lookup table from the static project data embedded in the page.
+ */
+function buildStaticLookup() {
+    const el = document.getElementById("static-project-data");
+    if (!el) return {};
+
+    let data;
+    try {
+        data = JSON.parse(el.textContent);
+    } catch (e) {
+        console.error("Failed to parse static project data:", e);
+        return {};
+    }
+
+    const lookup = {};
+    for (const proj of data) {
+        const key = normalizeProjectName(proj.name);
+        lookup[key] = proj;
+    }
+    return lookup;
+}
+
+/**
+ * Render the superblock summary header.
+ */
+function renderSuperblockHeader(sb, totalWhitelisted) {
+    const el = document.getElementById("superblock-info");
+    if (!el || !sb) return;
+
+    el.innerHTML = `
+        <div class="row text-center mb-3">
+            <div class="col-6 col-md-3">
+                <strong>Whitelisted Projects</strong><br>${totalWhitelisted} (${sb.total_projects} in superblock)
+            </div>
+            <div class="col-6 col-md-3">
+                <strong>Active Beacons</strong><br>${formatNumber(sb.active_beacons)}
+            </div>
+            <div class="col-6 col-md-3">
+                <strong>Total CPIDs</strong><br>${formatNumber(sb.total_cpids)}
+            </div>
+            <div class="col-6 col-md-3">
+                <strong>Superblock Height</strong><br>${formatNumber(sb.height)}
+            </div>
+        </div>
+        <p class="text-muted text-center mb-0"><small>Last superblock: ${sb.date} | Total magnitude: ${formatNumber(sb.total_magnitude)}</small></p>
+    `;
+    el.style.display = "";
+}
+
+/**
+ * Render the dynamic project table.
+ */
+function renderProjectTable(apiProjects, staticLookup) {
+    const tbody = document.getElementById("project-table-body");
+    if (!tbody) return;
+
+    // Sort projects: active first, then greylisted, then excluded.
+    const sortOrder = { "Active": 0, "Excluded": 1, "Greylisted": 2 };
+    const entries = Object.entries(apiProjects).sort((a, b) => {
+        const sa = projectStatus(a[1]).text;
+        const sb = projectStatus(b[1]).text;
+        const orderDiff = (sortOrder[sa] || 9) - (sortOrder[sb] || 9);
+        if (orderDiff !== 0) return orderDiff;
+        return a[0].localeCompare(b[0]);
+    });
+
+    let html = "";
+    for (const [name, proj] of entries) {
+        const status = projectStatus(proj);
+        const staticKey = normalizeProjectName(name);
+        const staticData = staticLookup[staticKey] || {};
+
+        const displayName = proj.display_name || staticData.name || name;
+        const projectUrl = staticData.link || proj.display_url || "#";
+        const goal = staticData.goal || "";
+        const sponsor = staticData.sponsor || "";
+
+        // CPU column — green fill for yes, red for no
+        const hasCpu = staticData.cpu === "yes";
+        const cpuCell = hasCpu ? "✔️" : "❌";
+        const cpuClass = hasCpu ? "table-color-yes" : "table-color-no";
+
+        // GPU column — vendor badges or red X
+        const hasGpu = staticData.gpu !== "no" && (
+            staticData.nvidia === "yes" || staticData.amd === "yes" || staticData.intel === "yes"
+        );
+        let gpuCell = "";
+        if (staticData.nvidia === "yes") gpuCell += '<img src="/assets/img/nvidia_badge.png" height="40"> ';
+        if (staticData.amd === "yes") gpuCell += '<img src="/assets/img/amd_badge.png" height="50"> ';
+        if (staticData.intel === "yes") gpuCell += '<img src="/assets/img/intel_badge.png" height="40"> ';
+        if (!gpuCell) gpuCell = "❌";
+        const gpuClass = hasGpu ? "table-color-yes" : "table-color-no";
+
+        // GDPR — driven dynamically from the API's gdpr_controls field,
+        // with static data providing the project-specific enable-steps link.
+        // Falls back to the general GDPR guide if no project-specific link.
+        const gdprRequired = proj.gdpr_controls === true;
+        let gdprCell = "not required";
+        let gdprClass = "";
+        if (gdprRequired) {
+            const gdprLink = staticData["gdpr-enable-steps"] || "/guides/gdpr-stats-export.htm";
+            gdprCell = `<a href="${gdprLink}">required <span class="oi oi-warning"></span></a>`;
+            gdprClass = "table-color-gdpr-yes";
+        }
+
+        // Team link
+        const teamLink = staticData.team
+            ? `<a href="${staticData.team}" title="Gridcoin Team">📊</a>`
+            : "";
+
+        // Stats link
+        const statsLink = staticData.stats
+            ? `<a href="${staticData.stats}" title="Project Stats">📈</a>`
+            : (proj.stats_url ? `<a href="${proj.stats_url}" title="Project Stats">📈</a>` : "");
+
+        // Greylist health — ZCD/WAS not available until v13 hardfork activates
+        // autogreylisting. If no projects have greylist data, show N/A.
+        let healthCell = "N/A";
+        if (proj.zcd !== undefined) {
+            const wasDisplay = proj.was !== undefined ? proj.was.toFixed(2) : "—";
+            healthCell = `ZCD: ${proj.zcd} / WAS: ${wasDisplay}`;
+        }
+
+        html += `<tr class="${status.cssClass}">
+            <td><a href="${projectUrl}">${displayName}</a>
+                ${status.text !== "Active" ? `<br><span class="${status.cssClass}">(${status.text})</span>` : ""}
+            </td>
+            <td class="d-none d-lg-table-cell">${goal}</td>
+            <td class="d-none d-lg-table-cell">${sponsor}</td>
+            <td><span class="badge bg-${status.text === 'Active' ? 'success' : status.text === 'Excluded' ? 'warning' : 'danger'}">${status.text}</span></td>
+            <td class="text-end">${formatCompact(proj.rac)}</td>
+            <td class="text-end d-none d-md-table-cell">${formatCompact(proj.total_credit)}</td>
+            <td class="text-end d-none d-md-table-cell">${proj.cpid_count !== undefined ? formatNumber(proj.cpid_count) : "—"}</td>
+            <td class="${cpuClass} d-none d-lg-table-cell">${cpuCell}</td>
+            <td class="${gpuClass} d-none d-lg-table-cell">${gpuCell}</td>
+            <td class="${gdprClass} d-none d-xl-table-cell">${gdprCell}</td>
+            <td class="d-none d-xl-table-cell">${healthCell}</td>
+            <td>${teamLink} ${statsLink}</td>
+        </tr>`;
+    }
+
+    tbody.innerHTML = html;
+}
+
+/**
+ * Main: fetch API data and render the dynamic table.
+ */
+function initWhitelist() {
+    const staticLookup = buildStaticLookup();
+    const dynamicTable = document.getElementById("dynamic-whitelist");
+    const staticTable = document.getElementById("static-whitelist");
+    const apiError = document.getElementById("api-error");
+
+    fetch(API_URL)
+        .then(response => {
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+        })
+        .then(data => {
+            if (!data || !data.projects) throw new Error("Invalid API response");
+
+            const totalWhitelisted = Object.keys(data.projects).length;
+            renderSuperblockHeader(data.superblock, totalWhitelisted);
+            renderProjectTable(data.projects, staticLookup);
+
+            // Show dynamic table, hide static fallback.
+            if (dynamicTable) dynamicTable.style.display = "";
+            if (staticTable) staticTable.style.display = "none";
+
+        })
+        .catch(error => {
+            console.error("Failed to fetch network status:", error);
+            // Keep the static table visible as fallback.
+            if (apiError) {
+                apiError.textContent = "Live data unavailable — showing cached information.";
+                apiError.style.display = "";
+            }
+        });
+}
+
+// Run when the DOM is ready.
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initWhitelist);
+} else {
+    initWhitelist();
+}

--- a/assets/js/pool-cpids.js
+++ b/assets/js/pool-cpids.js
@@ -1,0 +1,26 @@
+/**
+ * pool-cpids.js — known Gridcoin pool CPIDs, mirrored from the
+ * hardcoded list in src/gridcoin/researcher.h:86-90 (MiningPools
+ * constructor) of the Gridcoin-Research repo.
+ *
+ * Used by fetch-top-cpids.js to badge pool entries on the leaderboard
+ * and by the "Hide pools" toggle to filter them out.
+ *
+ * The Gridcoin codebase has a TODO to turn this into a fully
+ * functional registry (see the comment on the MiningPools class). Once
+ * that registry exists and is exposed via RPC / a new API endpoint,
+ * this file should switch from a static map to an async fetch — no
+ * other consumer changes needed because they all read window.POOL_CPIDS
+ * after a known-resolved point.
+ */
+window.POOL_CPIDS = new Map([
+    ["7d0d73fe026d66fd4ab8d5d8da32a611", { name: "grcpool.com",      url: "https://grcpool.com/" }],
+    ["a914eba952be5dfcf73d926b508fd5fa", { name: "grcpool.com-2",    url: "https://grcpool.com/" }],
+    ["163f049997e8a2dee054d69a7720bf05", { name: "grcpool.com-3",    url: "https://grcpool.com/" }],
+    ["f1f4d4e93b5b319b0a54b09dd47f1486", { name: "grcpool.com-5",    url: "https://grcpool.com/" }],
+    ["326bb50c0dd0ba9d46e15fae3484af35", { name: "grc.arikado.pool", url: "https://gridcoinpool.ru/" }],
+]);
+
+window.isPoolCpid = function(cpid) {
+    return window.POOL_CPIDS && window.POOL_CPIDS.has(cpid);
+};

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -187,6 +187,25 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 <canvas id="cpid-sand-chart"></canvas>
             </div>
 
+            <!-- 6. Daily MRC payments (stacked area + count line) ----------->
+
+            <h3 class="mb-3">MRC (Manual Research Claim) payments per day</h3>
+            <p class="text-muted">
+                Daily volume of MRC research-reward payments, stacked
+                by where each GRC ends up: <strong>net to researcher</strong>,
+                <strong>foundation fee</strong>, and <strong>staker fee</strong>.
+                The dotted red line on the secondary axis is the per-day
+                count of MRCs paid (typically much smaller than the GRC
+                amounts, hence its own scale). Sourced via
+                <code>getmrcinfo</code> RPC bracketed by daily UTC block
+                boundaries.
+            </p>
+
+            <div class="chart-container position-relative mb-5"
+                 style="height: 480px; width: 100%;">
+                <canvas id="mrc-daily-chart"></canvas>
+            </div>
+
         </div>
     </div>
 </section>
@@ -202,3 +221,4 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 <script src="/assets/js/fetch-project-active-cpids.js"></script>
 <script src="/assets/js/fetch-top-cpids.js"></script>
 <script src="/assets/js/fetch-cpid-sand.js"></script>
+<script src="/assets/js/fetch-mrc-daily.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -32,6 +32,12 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                         Mandatory release (labeled at top of line)
                     </span>
                     <span class="d-inline-flex align-items-center gap-2">
+                        <span style="display:inline-block; width:2px; height:14px;
+                                     background:repeating-linear-gradient(to bottom,
+                                        rgba(255,165,0,0.85) 0 5px, transparent 5px 8px);"></span>
+                        Block-version activation (post-grace, unlabeled)
+                    </span>
+                    <span class="d-inline-flex align-items-center gap-2">
                         <span style="display:inline-block; width:2px; height:14px; background:rgba(200,200,200,0.35);"></span>
                         Year boundary (Jan 1)
                     </span>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -130,6 +130,43 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 </table>
             </div>
 
+            <!-- 5. CPID sand chart (stacked area by project) ------------->
+
+            <h3 class="mb-3">Magnitude contribution by project for a CPID</h3>
+            <p class="text-muted">
+                Stacked-area ("sand") chart of a single CPID's magnitude
+                broken down by project over time. Start typing a hex
+                prefix to pick from the autocomplete list, or paste a
+                full CPID (copied from the leaderboard above, for
+                example) and press <kbd>Enter</kbd>.
+            </p>
+
+            <div class="row g-2 align-items-center mb-3">
+                <div class="col-auto">
+                    <label for="cpid-sand-input" class="col-form-label">CPID:</label>
+                </div>
+                <div class="col-auto">
+                    <input list="cpid-sand-list" id="cpid-sand-input"
+                           class="form-control form-control-sm"
+                           style="width: 360px; font-family: monospace;"
+                           placeholder="32-char hex prefix or full">
+                    <datalist id="cpid-sand-list"></datalist>
+                </div>
+                <div class="col-auto">
+                    <button id="cpid-sand-render" class="btn btn-sm btn-primary">Show</button>
+                </div>
+                <div class="col-auto">
+                    <span id="cpid-sand-loading" class="text-muted small" style="display:none;">Loading…</span>
+                </div>
+            </div>
+            <div id="cpid-sand-autocomplete-hint" class="text-muted small mb-1"></div>
+            <div id="cpid-sand-status" class="text-muted small mb-2"></div>
+
+            <div class="chart-container position-relative mb-5"
+                 style="height: 480px; width: 100%;">
+                <canvas id="cpid-sand-chart"></canvas>
+            </div>
+
         </div>
     </div>
 </section>
@@ -141,3 +178,4 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 <script src="/assets/js/fetch-project-churn.js"></script>
 <script src="/assets/js/fetch-project-active-cpids.js"></script>
 <script src="/assets/js/fetch-top-cpids.js"></script>
+<script src="/assets/js/fetch-cpid-sand.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -129,20 +129,20 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 
             <!-- 5. Top researchers --------------------------------------->
 
-            <h3 class="mb-3">Top researchers by lifetime magnitude</h3>
+            <h3 class="mb-3">Top researchers by magnitude</h3>
             <p class="text-muted">
                 Default ranking is by <em>total observed magnitude</em>
-                (sum of daily magnitude across every day the CPID appeared
-                in the observed window). Because the observed history
-                begins on 2020-09-09, CPIDs that were contributing earlier
-                are indirectly penalised — but this remains the most
-                honest cumulative measure for the captured window. Click
-                any numeric header to re-rank. Use the project filter to
-                restrict the ranking to one project's contributors.
-                Pool CPIDs aggregate many crunchers and dominate the
-                top of the lifetime ranking; they're tagged with a
-                badge linking to the pool's site. Toggle <em>Hide pool
-                CPIDs</em> to rank only individual researchers.
+                (sum of daily magnitude across every day in the selected
+                window). All-time covers the full observed history (since
+                2020-09-09); the canned periods (week / month / quarter /
+                year) are rolling windows ending today. Pick <em>Custom
+                range</em> to enter explicit dates. Click any numeric
+                header to re-rank. Use the project filter to restrict the
+                ranking to one project's contributors. Pool CPIDs aggregate
+                many crunchers and dominate the top of the lifetime
+                ranking; they're tagged with a badge linking to the pool's
+                site. Toggle <em>Hide pool CPIDs</em> to rank only
+                individual researchers.
             </p>
 
             <div class="row g-2 align-items-center mb-3">
@@ -153,6 +153,33 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                     <select id="top-cpids-project" class="form-select form-select-sm">
                         <option value="">Network-wide (all projects)</option>
                     </select>
+                </div>
+                <div class="col-auto">
+                    <label for="top-cpids-period" class="col-form-label ms-2">Period:</label>
+                </div>
+                <div class="col-auto">
+                    <select id="top-cpids-period" class="form-select form-select-sm">
+                        <option value="all" selected>All time</option>
+                        <option value="week">Past week</option>
+                        <option value="month">Past month</option>
+                        <option value="quarter">Past quarter</option>
+                        <option value="year">Past year</option>
+                        <option value="custom">Custom range…</option>
+                    </select>
+                </div>
+                <div class="col-auto top-cpids-custom-range" style="display:none;">
+                    <input type="date" id="top-cpids-start-date"
+                           class="form-control form-control-sm" style="width: 160px;">
+                </div>
+                <div class="col-auto top-cpids-custom-range" style="display:none;">
+                    <span class="col-form-label">to</span>
+                </div>
+                <div class="col-auto top-cpids-custom-range" style="display:none;">
+                    <input type="date" id="top-cpids-end-date"
+                           class="form-control form-control-sm" style="width: 160px;">
+                </div>
+                <div class="col-auto top-cpids-custom-range" style="display:none;">
+                    <button id="top-cpids-apply-range" class="btn btn-sm btn-primary">Apply</button>
                 </div>
                 <div class="col-auto">
                     <label for="top-cpids-limit" class="col-form-label ms-2">Show top:</label>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -1,0 +1,143 @@
+---
+title: "Gridcoin - Network Analytics"
+description: "Historical time-series analytics on Gridcoin network activity — CPID churn, project participation, and more."
+---
+
+<section class="grc-bgcolor grclink mb-4">
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <h2 class="text-center fw-bold">Network Analytics</h2>
+                <p class="text-center mb-0">
+                    Daily snapshots of Gridcoin network activity since September 2020,
+                    derived from the Scraper's converged superblock statistics.
+                </p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="container mb-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-10">
+
+            <div id="analytics-error" class="alert alert-warning"
+                 style="display:none;" role="alert"></div>
+
+            <!-- 1. CPID activity ------------------------------------------>
+
+            <h3 class="mb-3">CPID activity over time</h3>
+            <p class="text-muted">
+                Each data point is one day. The blue line (left axis) is
+                the count of distinct CPIDs that appeared in the superblock
+                that day with positive magnitude. The green and red lines
+                (right axis) are the daily gross flows: <em>Churn in</em>
+                (active today, not yesterday) and <em>Churn out</em>
+                (active yesterday, not today). Any dataset can be hidden
+                by clicking its entry in the legend. Values on the very
+                first and last day of the series — and on days adjacent
+                to a data gap — are undefined.
+            </p>
+            <div class="chart-container position-relative mb-5"
+                 style="height: 480px; width: 100%;">
+                <canvas id="cpid-churn-chart"></canvas>
+            </div>
+
+            <!-- 2. Project whitelist churn -------------------------------->
+
+            <h3 class="mb-3">Project whitelist churn</h3>
+            <p class="text-muted">
+                Count of projects present in the day's superblock (blue,
+                left axis) and day-over-day additions / drops (green / red,
+                right axis). Note the protocol rule: each in-superblock
+                project gets an equal share of the network-wide 115 000
+                magnitude pool, so this count directly sets the per-project
+                baseline (115 000 / N).
+            </p>
+            <div class="chart-container position-relative mb-5"
+                 style="height: 380px; width: 100%;">
+                <canvas id="project-churn-chart"></canvas>
+            </div>
+
+            <!-- 3. Per-project active CPIDs ------------------------------->
+
+            <h3 class="mb-3">Active CPIDs per project over time</h3>
+            <p class="text-muted">
+                One line per project — each day's count of distinct CPIDs
+                with positive magnitude on that project. Click a project
+                name in the legend to hide or show its line. The set of
+                projects changes over time; lines disappear when a project
+                drops out of the superblock and reappear if it's re-added.
+            </p>
+            <div class="chart-container position-relative mb-5"
+                 style="height: 480px; width: 100%;">
+                <canvas id="project-active-cpids-chart"></canvas>
+            </div>
+
+            <!-- 4. Top researchers --------------------------------------->
+
+            <h3 class="mb-3">Top researchers by lifetime magnitude</h3>
+            <p class="text-muted">
+                Default ranking is by <em>total observed magnitude</em>
+                (sum of daily magnitude across every day the CPID appeared
+                in the observed window). Because the observed history
+                begins on 2020-09-09, CPIDs that were contributing earlier
+                are indirectly penalised — but this remains the most
+                honest cumulative measure for the captured window. Click
+                any numeric header to re-rank. Use the project filter to
+                restrict the ranking to one project's contributors.
+            </p>
+
+            <div class="row g-2 align-items-center mb-3">
+                <div class="col-auto">
+                    <label for="top-cpids-project" class="col-form-label">Scope:</label>
+                </div>
+                <div class="col-auto">
+                    <select id="top-cpids-project" class="form-select form-select-sm">
+                        <option value="">Network-wide (all projects)</option>
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <label for="top-cpids-limit" class="col-form-label ms-2">Show top:</label>
+                </div>
+                <div class="col-auto">
+                    <select id="top-cpids-limit" class="form-select form-select-sm">
+                        <option value="25">25</option>
+                        <option value="100" selected>100</option>
+                        <option value="250">250</option>
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <span id="top-cpids-loading" class="text-muted small" style="display:none;">Loading…</span>
+                </div>
+            </div>
+
+            <div class="table-responsive mb-5">
+                <table class="table table-sm table-custom-dark table-hover table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>CPID</th>
+                            <th class="text-end top-cpids-sort" data-order="days_active">Days active</th>
+                            <th class="text-end top-cpids-sort" data-order="lifetime_mag_sum">Lifetime mag (total)</th>
+                            <th class="text-end top-cpids-sort" data-order="lifetime_mag_avg_active">Lifetime mag (active avg)</th>
+                            <th class="text-end top-cpids-sort" data-order="lifetime_mag_avg_elapsed">Lifetime mag (elapsed avg)</th>
+                            <th>First seen</th>
+                            <th>Last seen</th>
+                        </tr>
+                    </thead>
+                    <tbody id="top-cpids-tbody"></tbody>
+                </table>
+            </div>
+
+        </div>
+    </div>
+</section>
+
+<!-- Chart.js (UMD bundle pinned to a major version) -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="/assets/js/analytics-api.js"></script>
+<script src="/assets/js/fetch-cpid-churn.js"></script>
+<script src="/assets/js/fetch-project-churn.js"></script>
+<script src="/assets/js/fetch-project-active-cpids.js"></script>
+<script src="/assets/js/fetch-top-cpids.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -196,9 +196,11 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 <strong>foundation fee</strong>, and <strong>staker fee</strong>.
                 The dotted red line on the secondary axis is the per-day
                 count of MRCs paid (typically much smaller than the GRC
-                amounts, hence its own scale). Sourced via
-                <code>getmrcinfo</code> RPC bracketed by daily UTC block
-                boundaries.
+                amounts, hence its own scale). All series are smoothed
+                with a trailing 7-day moving average to suppress the
+                day-to-day spikes from individual large MRC claims.
+                Sourced via <code>getmrcinfo</code> RPC bracketed by
+                daily UTC block boundaries.
             </p>
 
             <div class="chart-container position-relative mb-5"

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -139,6 +139,10 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 honest cumulative measure for the captured window. Click
                 any numeric header to re-rank. Use the project filter to
                 restrict the ranking to one project's contributors.
+                Pool CPIDs aggregate many crunchers and dominate the
+                top of the lifetime ranking; they're tagged with a
+                badge linking to the pool's site. Toggle <em>Hide pool
+                CPIDs</em> to rank only individual researchers.
             </p>
 
             <div class="row g-2 align-items-center mb-3">
@@ -159,6 +163,14 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                         <option value="100" selected>100</option>
                         <option value="250">250</option>
                     </select>
+                </div>
+                <div class="col-auto">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="top-cpids-hide-pools">
+                        <label class="form-check-label small" for="top-cpids-hide-pools">
+                            Hide pool CPIDs
+                        </label>
+                    </div>
                 </div>
                 <div class="col-auto">
                     <span id="top-cpids-loading" class="text-muted small" style="display:none;">Loading…</span>
@@ -230,6 +242,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
 <script src="/assets/js/analytics-api.js"></script>
 <script src="/assets/js/chart-helpers.js"></script>
+<script src="/assets/js/pool-cpids.js"></script>
 <script src="/assets/js/fetch-cpid-churn.js"></script>
 <script src="/assets/js/fetch-project-churn.js"></script>
 <script src="/assets/js/fetch-project-active-cpids.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -24,6 +24,26 @@ description: "Historical time-series analytics on Gridcoin network activity — 
             <div id="analytics-error" class="alert alert-warning"
                  style="display:none;" role="alert"></div>
 
+            <!-- Annotation legend -->
+            <div class="mb-3 small">
+                <div class="d-flex flex-wrap gap-4 align-items-center">
+                    <span class="d-inline-flex align-items-center gap-2">
+                        <span style="display:inline-block; width:2px; height:14px; background:rgba(255,165,0,0.85);"></span>
+                        Mandatory release (labeled at top of line)
+                    </span>
+                    <span class="d-inline-flex align-items-center gap-2">
+                        <span style="display:inline-block; width:2px; height:14px; background:rgba(200,200,200,0.35);"></span>
+                        Year boundary (Jan 1)
+                    </span>
+                    <span class="d-inline-flex align-items-center gap-2">
+                        <span style="display:inline-block; width:2px; height:14px;
+                                     background:repeating-linear-gradient(to bottom,
+                                        rgba(200,200,200,0.25) 0 2px, transparent 2px 6px);"></span>
+                        Quarter boundary (Apr / Jul / Oct 1)
+                    </span>
+                </div>
+            </div>
+
             <!-- 1. CPID activity ------------------------------------------>
 
             <h3 class="mb-3">CPID activity over time</h3>
@@ -173,7 +193,10 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 
 <!-- Chart.js (UMD bundle pinned to a major version) -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<!-- chartjs-plugin-annotation v3 (compatible with Chart.js v4) -->
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
 <script src="/assets/js/analytics-api.js"></script>
+<script src="/assets/js/chart-helpers.js"></script>
 <script src="/assets/js/fetch-cpid-churn.js"></script>
 <script src="/assets/js/fetch-project-churn.js"></script>
 <script src="/assets/js/fetch-project-active-cpids.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -197,10 +197,12 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 The dotted red line on the secondary axis is the per-day
                 count of MRCs paid (typically much smaller than the GRC
                 amounts, hence its own scale). All series are smoothed
-                with a trailing 7-day moving average to suppress the
-                day-to-day spikes from individual large MRC claims.
-                Sourced via <code>getmrcinfo</code> RPC bracketed by
-                daily UTC block boundaries.
+                with a centered 14-day moving average (each point is
+                the mean of the surrounding 14 days, half before and
+                half after) to suppress the day-to-day spikes from
+                individual large MRC claims while preserving the
+                longer-term trend. Sourced via <code>getmrcinfo</code>
+                RPC bracketed by daily UTC block boundaries.
             </p>
 
             <div class="chart-container position-relative mb-5"

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -63,7 +63,34 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 <canvas id="cpid-churn-chart"></canvas>
             </div>
 
-            <!-- 2. Project whitelist churn -------------------------------->
+            <!-- 2. Daily MRC payments (stacked area + count line) ----------->
+
+            <h3 class="mb-3">MRC (Manual Research Claim) payments per day</h3>
+            <p class="text-muted">
+                Daily volume of MRC research-reward payments, stacked
+                by where each GRC ends up: <strong>net to researcher</strong>,
+                <strong>foundation fee</strong>, and <strong>staker fee</strong>.
+                The dotted red line on the secondary axis is the per-day
+                count of MRCs paid (typically much smaller than the GRC
+                amounts, hence its own scale). All series are smoothed
+                with a centered 14-day moving average (each point is
+                the mean of the surrounding 14 days, half before and
+                half after) to suppress the day-to-day spikes from
+                individual large MRC claims while preserving the
+                longer-term trend. The x-axis is aligned to the CPID-
+                activity chart above; MRC support didn't exist before
+                v12 (block height 2&#8239;671&#8239;700, mainnet
+                2022-08-28), so the leading portion of the series is
+                zero by construction. Sourced via <code>getmrcinfo</code>
+                RPC bracketed by daily UTC block boundaries.
+            </p>
+
+            <div class="chart-container position-relative mb-5"
+                 style="height: 480px; width: 100%;">
+                <canvas id="mrc-daily-chart"></canvas>
+            </div>
+
+            <!-- 3. Project whitelist churn -------------------------------->
 
             <h3 class="mb-3">Project whitelist churn</h3>
             <p class="text-muted">
@@ -79,7 +106,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 <canvas id="project-churn-chart"></canvas>
             </div>
 
-            <!-- 3. Per-project active CPIDs ------------------------------->
+            <!-- 4. Per-project active CPIDs ------------------------------->
 
             <h3 class="mb-3">Active CPIDs per project over time</h3>
             <p class="text-muted">
@@ -94,7 +121,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 <canvas id="project-active-cpids-chart"></canvas>
             </div>
 
-            <!-- 4. Top researchers --------------------------------------->
+            <!-- 5. Top researchers --------------------------------------->
 
             <h3 class="mb-3">Top researchers by lifetime magnitude</h3>
             <p class="text-muted">
@@ -150,7 +177,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                 </table>
             </div>
 
-            <!-- 5. CPID sand chart (stacked area by project) ------------->
+            <!-- 6. CPID sand chart (stacked area by project) ------------->
 
             <h3 id="cpid-sand-section" class="mb-3">Magnitude contribution by project for a CPID</h3>
             <p class="text-muted">
@@ -185,29 +212,6 @@ description: "Historical time-series analytics on Gridcoin network activity — 
             <div class="chart-container position-relative mb-5"
                  style="height: 480px; width: 100%;">
                 <canvas id="cpid-sand-chart"></canvas>
-            </div>
-
-            <!-- 6. Daily MRC payments (stacked area + count line) ----------->
-
-            <h3 class="mb-3">MRC (Manual Research Claim) payments per day</h3>
-            <p class="text-muted">
-                Daily volume of MRC research-reward payments, stacked
-                by where each GRC ends up: <strong>net to researcher</strong>,
-                <strong>foundation fee</strong>, and <strong>staker fee</strong>.
-                The dotted red line on the secondary axis is the per-day
-                count of MRCs paid (typically much smaller than the GRC
-                amounts, hence its own scale). All series are smoothed
-                with a centered 14-day moving average (each point is
-                the mean of the surrounding 14 days, half before and
-                half after) to suppress the day-to-day spikes from
-                individual large MRC claims while preserving the
-                longer-term trend. Sourced via <code>getmrcinfo</code>
-                RPC bracketed by daily UTC block boundaries.
-            </p>
-
-            <div class="chart-container position-relative mb-5"
-                 style="height: 480px; width: 100%;">
-                <canvas id="mrc-daily-chart"></canvas>
             </div>
 
         </div>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -263,10 +263,17 @@ description: "Historical time-series analytics on Gridcoin network activity — 
     </div>
 </section>
 
-<!-- Chart.js (UMD bundle pinned to a major version) -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-<!-- chartjs-plugin-annotation v3 (compatible with Chart.js v4) -->
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
+<!-- Chart.js — pinned to an exact version with Subresource Integrity so a
+     compromised or silently-rotated CDN response can't ship arbitrary JS
+     into the page. Update both the version in the URL and the integrity
+     hash together when bumping. -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+        integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+        crossorigin="anonymous"></script>
+<!-- chartjs-plugin-annotation v3 (compatible with Chart.js v4) — same SRI rules. -->
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.1.0/dist/chartjs-plugin-annotation.min.js"
+        integrity="sha384-3N9GHhCtN3CQef6tNfqgZlv7sQLYIkcChN+uaTZ7xVdzKYp/SjBNPxa92+hM7EAY"
+        crossorigin="anonymous"></script>
 <script src="/assets/js/analytics-api.js"></script>
 <script src="/assets/js/chart-helpers.js"></script>
 <script src="/assets/js/pool-cpids.js"></script>

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -152,7 +152,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
 
             <!-- 5. CPID sand chart (stacked area by project) ------------->
 
-            <h3 class="mb-3">Magnitude contribution by project for a CPID</h3>
+            <h3 id="cpid-sand-section" class="mb-3">Magnitude contribution by project for a CPID</h3>
             <p class="text-muted">
                 Stacked-area ("sand") chart of a single CPID's magnitude
                 broken down by project over time. Start typing a hex

--- a/guides/analytics.htm
+++ b/guides/analytics.htm
@@ -35,7 +35,7 @@ description: "Historical time-series analytics on Gridcoin network activity — 
                         <span style="display:inline-block; width:2px; height:14px;
                                      background:repeating-linear-gradient(to bottom,
                                         rgba(255,165,0,0.85) 0 5px, transparent 5px 8px);"></span>
-                        Block-version activation (post-grace, unlabeled)
+                        Block-version activation (post-grace, labeled vN)
                     </span>
                     <span class="d-inline-flex align-items-center gap-2">
                         <span style="display:inline-block; width:2px; height:14px; background:rgba(200,200,200,0.35);"></span>

--- a/guides/whitelist.htm
+++ b/guides/whitelist.htm
@@ -6,64 +6,104 @@ redirect_from:
 ---
 <section class="whitelist grc-bgcolor grclink mb-5">
         <!--Start of GRC Feature section-->
-        <!--First row of features-->
         <div class="container">
             <div class="row">
                 <div class="col-12 col-sm-4">
                     <h3>Important</h3>
                             <p><ul><li>You will only be rewarded Gridcoin for whitelisted BOINC projects. Any BOINC work done outside of the whitelisted BOINC projects will not be rewarded</li>
-                            <li> Some of these projects may currently be on the greylist <b>The most accurate source</b> for whitelist/greylist information will always be your Gridcoin wallet. </li> 
-                            <li> There are a total of {{ site.data.whitelist.projects.size }} projects whitelisted </li>
+                            <li> Some of these projects may currently be on the greylist or temporarily excluded from the superblock. </li>
                             <li> You can check whitelisted project details on <a href="https://gridcoinstats.eu/project">Gridcoinstats</a>. </li>
                             </p>
                 </div>
                 <div class='col-12 col-sm-8'>
                     <h3>Greylist</h3>
-                    <p>When projects are running out of work or are offline for temporary maintenance they are placed on the Greylist.  These projects will not reward Gridcoin until they meet the requirements to be placed back on the whitelist again.  Please see various social media (Twitter, Facebook, Reddit, Slack) for notices about greylisted projects.</p>
+                    <p>When projects are running out of work or are offline for temporary maintenance they are placed on the Greylist. These projects will not reward Gridcoin until they meet the requirements to be placed back on the whitelist again. Please see various social media (Twitter, Facebook, Reddit, Slack) for notices about greylisted projects.</p>
+                    <p>Projects may also be temporarily <strong>excluded</strong> from the superblock if their statistics have not been updated for more than 48 hours. This is different from greylisting — the project remains whitelisted but cannot earn rewards until stats resume.</p>
                     <p>The <a href="/wiki/whitelist-process.html#greylist">whitelist process wiki page</a> outlines the Greylist procedure for all whitelisted projects.</p>
                 </div>
             </div>
         </div>
-        <!--End of GRC Feature Section-->
 </section>
 
 <section class="whitelist-2 text-center">
     <h2 class="mb-2 anchor-adjust" id="projects">Whitelisted Projects</h2>
-    <div class="mb-4">
-    <p>To check if a project is on the greylist, in your wallet go to Hamburger Menu > Settings > Researcher Wizard > Projects (or the <code>listprojects</code> command) <br>
-    Any project shown is not greylisted. Your wallet must be fully synced for the latest info.</p>
-    </div>
-    <!-- BOINC Content -->
-    <div class="container">
+
+    <!-- API error banner (hidden by default) -->
+    <div id="api-error" class="alert alert-warning mx-auto" style="display:none; max-width: 600px;"></div>
+
+    <!-- Superblock summary (populated by JS) -->
+    <div id="superblock-info" class="container mb-4" style="display:none;"></div>
+
+    <!-- Static project data for JS to merge (hidden, consumed by fetch-whitelist.js) -->
+    <script id="static-project-data" type="application/json">
+    [{% for project in site.data.whitelist.projects %}
+        {
+            "name": {{ project.name | jsonify }},
+            "link": {{ project.link | jsonify }},
+            "goal": {{ project.goal | jsonify }},
+            "sponsor": {{ project.sponsor | jsonify }},
+            "cpu": {{ project.cpu | jsonify }},
+            "gpu": {{ project.gpu | jsonify }},
+            "nvidia": {{ project.nvidia | jsonify }},
+            "amd": {{ project.amd | jsonify }},
+            "intel": {{ project.intel | jsonify }},
+            "gdpr": {{ project.gdpr | jsonify }},
+            "gdpr-enable-steps": {{ project.gdpr-enable-steps | jsonify }},
+            "team": {{ project.team | jsonify }},
+            "stats": {{ project.stats | jsonify }}
+        }{% unless forloop.last %},{% endunless %}
+    {% endfor %}]
+    </script>
+
+    <!-- Dynamic table (hidden until JS populates it) -->
+    <div class="container" id="dynamic-whitelist" style="display:none;">
         <div class="row text-center mb-5">
-            <div class="col-12 d-none d-md-block">
+            <div class="col-12">
+                <div class="table-responsive">
                 <table class="table table-sm table-custom-dark table-hover table-striped table-bordered">
                     <thead>
                         <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                Goal
-                            </th>
-                            <th>
-                                Sponsor
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                <dfn data-toggle="tooltip" data-placement="bottom" title="Projects listed here have GPU support, but availability of GPU workunits is not guaranteed">GPU</dfn>
-                            </th>
-                            <th>
-                                <dfn data-toggle="tooltip" data-placement="bottom" title="Some projects require you to opt-in to exporting your stats. You will need to do this to earn GRC for your work">GDPR Stats Export</dfn>
-                            </th>
-                            <th>
-                                Team
-                            </th>
-                            <th>
-                                Stats
-                            </th>
+                            <th>Project</th>
+                            <th class="d-none d-lg-table-cell">Goal</th>
+                            <th class="d-none d-lg-table-cell">Sponsor</th>
+                            <th>Status</th>
+                            <th>RAC</th>
+                            <th class="d-none d-md-table-cell">Network Credit</th>
+                            <th class="d-none d-md-table-cell">CPIDs</th>
+                            <th class="d-none d-lg-table-cell">CPU</th>
+                            <th class="d-none d-lg-table-cell"><dfn title="Projects listed here have GPU support, but availability of GPU workunits is not guaranteed">GPU</dfn></th>
+                            <th class="d-none d-xl-table-cell"><dfn title="Some projects require you to opt-in to exporting your stats to earn GRC">GDPR</dfn></th>
+                            <th class="d-none d-xl-table-cell"><dfn title="Zero Credit Days / Whitelist Activity Score — greylist health indicators">ZCD / WAS</dfn></th>
+                            <th>Links</th>
+                        </tr>
+                    </thead>
+                    <tbody id="project-table-body">
+                    </tbody>
+                </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Static fallback table (shown by default, hidden when JS loads dynamic data) -->
+    <div class="container" id="static-whitelist">
+        <div class="mb-4">
+        <p>To check if a project is on the greylist, in your wallet go to Hamburger Menu > Settings > Researcher Wizard > Projects (or the <code>listprojects</code> command) <br>
+        Any project shown is not greylisted. Your wallet must be fully synced for the latest info.</p>
+        </div>
+        <div class="row text-center mb-5">
+            <div class="col-12">
+                <table class="table table-sm table-custom-dark table-hover table-striped table-bordered">
+                    <thead>
+                        <tr>
+                            <th>Project</th>
+                            <th>Goal</th>
+                            <th>Sponsor</th>
+                            <th>CPU</th>
+                            <th><dfn title="Projects listed here have GPU support, but availability of GPU workunits is not guaranteed">GPU</dfn></th>
+                            <th><dfn title="Some projects require you to opt-in to exporting your stats. You will need to do this to earn GRC for your work">GDPR Stats Export</dfn></th>
+                            <th>Team</th>
+                            <th>Stats</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -72,192 +112,75 @@ redirect_from:
                                 <td{% if project.greylisted == "yes" %} class="greylisted"{% endif %}>
                                     <a href="{{ project.link }}">{{ project.name }}</a>{% if project.greylisted == "yes" %}<br><span class="greylisted">(greylisted)</span>{% endif %}
                                 </td>
-                                <td>
-                                    {{ project.goal }}
-                                </td>
-                                <td>
-                                    {{ project.sponsor }}
-                                </td>
-                                <td class="table-color-{{project.cpu}}">{% comment %} uses either table-color-yes or table-color-no for the class (green or red coloring) {% endcomment %}
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
+                                <td>{{ project.goal }}</td>
+                                <td>{{ project.sponsor }}</td>
+                                <td class="table-color-{{project.cpu}}">
+                                    {% if project.cpu == "yes" %}✔️{% else %}❌{% endif %}
                                 </td>
                                 <td class="table-color-{{project.gpu}}">
-                                    {% if project.gpu == "no" %}
-                                      ❌                                    
-                                    {% endif %}
-                                    {% if project.nvidia == "yes" %}
-                                      <img src="/assets/img/nvidia_badge.png" height="40">                                       
-                                    {% endif %}
-                                    {% if project.amd == "yes" %}
-                                      <img src="/assets/img/amd_badge.png" height="50">
-                                    {% endif %}
-                                    {% if project.intel == "yes" %}
-                                    <img src="/assets/img/intel_badge.png" height="40">
-                                    {% endif %}
+                                    {% if project.gpu == "no" %}❌{% endif %}
+                                    {% if project.nvidia == "yes" %}<img src="/assets/img/nvidia_badge.png" height="40">{% endif %}
+                                    {% if project.amd == "yes" %}<img src="/assets/img/amd_badge.png" height="50">{% endif %}
+                                    {% if project.intel == "yes" %}<img src="/assets/img/intel_badge.png" height="40">{% endif %}
                                 </td>
-                                <td {% if project.gdpr == "yes" %}class="table-color-gdpr-yes"{% endif %}> {% comment %} Add warning color for background only if it requires it. No color otherwise {% endcomment %}
+                                <td {% if project.gdpr == "yes" %}class="table-color-gdpr-yes"{% endif %}>
                                     {% if project.gdpr == "yes" %}
                                         <a href="{{ project['gdpr-enable-steps'] }}">required<span class="oi oi-warning"></span></a>
                                     {% else %}
                                       not required
                                     {% endif %}
                                 </td>
-                                <td>
-                                    <a href="{{ project.team }}" title="Gridcoin Team Link">📊</a>
-                                </td>
-                                <td>
-                                    <a href="{{ project.stats }}" title="Project stats">📈</a>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="col-12 d-none d-sm-block d-md-none">
-                <table class="table table-sm table-custom-dark table-hover table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                GPU
-                            </th>
-                            <th>
-                                GDPR Stats Export 
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for project in site.data.whitelist.projects %}
-                            <tr>
-                                <td{% if project.greylisted == "yes"%} class="greylisted"{% endif %}>
-                                    <a href="{{ project.link }}">{{ project.name }}</a>{% if project.greylisted == "yes" %}<br><span class="greylisted">(greylisted)</span>{% endif %}
-                                </td>
-                                <td class="table-color-{{project.cpu}}"> 
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td class="table-color-{{project.gpu}}">
-                                  {% if project.gpu == "no" %}
-                                  ❌                                    
-                                  {% endif %}
-                                  {% if project.nvidia == "yes" %}
-                                    <img src="/assets/img/nvidia_badge.png" height="40">                                       
-                                  {% endif %}
-                                  {% if project.amd == "yes" %}
-                                    <img src="/assets/img/amd_badge.png" height="50">
-                                  {% endif %}
-                                  {% if project.intel == "yes" %}
-                                    <img src="/assets/img/intel_badge.png" height="40">
-                                  {% endif %}
-                                </td>
-                                <td {% if project.gdpr == "yes" %}class="table-color-gdpr-yes"{% endif %}>
-                                    {% if project.gdpr == "yes" %}
-                                    <a href={{project.gdpr-enable-steps}}>required<span class="oi oi-warning"></span></a>
-                                    {% else %}
-                                      not required
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="col-12 d-sm-none">
-                <table class="table table-sm table-custom-dark table-hover table-striped table-bordered">
-                    <thead>
-                        <tr>
-                            <th>
-                                Project
-                            </th>
-                            <th>
-                                CPU
-                            </th>
-                            <th>
-                                GPU
-                            </th>
-                            <th>
-                                GDPR Stats Export
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for project in site.data.whitelist.projects %}
-                            <tr>
-                                <td{% if project.greylisted == "yes" %} class="greylisted"{% endif %}>
-                                    <a href="{{ project.link }}">{{ project.name }}</a>{% if project.greylisted == "yes" %}<br><span class="greylisted">(greylisted)</span>{% endif %}
-                                </td>
-                                <td class="table-color-{{project.cpu}}">
-                                    {% if project.cpu == "yes" %}
-                                      ✔️
-                                    {% else %}
-                                      ❌
-                                    {% endif %}
-                                </td>
-                                <td class="table-color-{{project.gpu}}">
-                                  {% if project.gpu == "no" %}
-                                    ❌                                    
-                                  {% endif %}
-                                  {% if project.nvidia == "yes" %}
-                                    <img src="/assets/img/nvidia_badge.png" height="40">                                       
-                                  {% endif %}
-                                  {% if project.amd == "yes" %}
-                                    <img src="/assets/img/amd_badge.png" height="50">
-                                  {% endif %}
-                                  {% if project.intel == "yes" %}
-                                    <img src="/assets/img/intel_badge.png" height="40">
-                                  {% endif %}
-                                </td>
-                                <td {% if project.gdpr == "yes" %}class="table-color-gdpr-yes"{% endif %}>
-                                    {% if project.gdpr == "yes" %}
-                                        <a href={{project.gdpr-enable-steps}}><span class="oi oi-warning"></span></a>
-                                    {% endif %}
-                                </td>
+                                <td><a href="{{ project.team }}" title="Gridcoin Team Link">📊</a></td>
+                                <td><a href="{{ project.stats }}" title="Project stats">📈</a></td>
                             </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
         </div>
-        <h3 id="about-gdpr" class="anchor-adjust">About GDPR</h3>
-            <p>GDPR is a law in the European Union on data privacy. Some projects have
-            interpreted it to mean that to sharing BOINC stats requires opting in. 
-            Solo crunchers must enable it to be rewarded because otherwise Gridcoin can't see how much work 
-            you've done and figure out how much you are owed</p>
-            
-            <p>NOTE: <u>Only solo crunchers on these projects need to follow these steps</u>.
-            Pool cruncher don't need to because your pool has already done it
-            </p>
-            
-
-            <p>Currently the whitelisted projects that require this are:<br>
-            {% for project in site.data.whitelist.projects %}
-                {% if project.gdpr == "yes" %}
-                    {{project.name}} (<a href={{project.gdpr-enable-steps}}>steps to enable</a>)<br>
-                {% endif %}
-            {% endfor %}</p>
-
-        <h3 id="whitelist-process" class="anchor-adjust">Whitelist Process</h3>
-            <p>Want a project whitelisted? Ask about it on the <code>#whitelisting-committee</code> channel on the Gridcoin Discord! More details about adding a project to the whitelist can be found on the <a href="/wiki/whitelist-process.html">whitelist process wiki page</a>
-            <p>The whitelist was created to increase security and to focus user's resources on active projects. See <a href="https://web.archive.org/web/20150416222027/cryptocointalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">historical discussion</a></p>
     </div>
-    </div>
-    
 
+    <!-- Column legend -->
+    <div class="container mb-5 text-start" id="table-legend">
+        <h3 class="anchor-adjust text-center" id="column-legend">Column Legend</h3>
+        <div class="row">
+            <div class="col-12 col-md-6">
+                <dl>
+                    <dt>Status</dt>
+                    <dd><span class="badge bg-success">Active</span> — project is whitelisted and in the current superblock, earning rewards.<br>
+                        <span class="badge bg-warning">Excluded</span> — project is whitelisted but temporarily excluded from the superblock because its statistics have not updated for more than 48 hours.<br>
+                        <span class="badge bg-danger">Greylisted</span> — project has been automatically or manually greylisted and is not earning rewards.
+                    </dd>
+                    <dt>RAC</dt>
+                    <dd>Recent Average Credit — the total RAC across all active Gridcoin researchers contributing to this project. This reflects Gridcoin network activity, not the BOINC project's total RAC.</dd>
+                    <dt>Network Credit</dt>
+                    <dd>Total credit earned by Gridcoin researchers on this project. This is the sum across active CPIDs on the Gridcoin network, not the BOINC project's total credit.</dd>
+                    <dt>CPIDs</dt>
+                    <dd>Number of Gridcoin researchers (unique CPIDs) actively contributing to this project.</dd>
+                </dl>
+            </div>
+            <div class="col-12 col-md-6">
+                <dl>
+                    <dt>CPU / GPU</dt>
+                    <dd>Whether the project supports CPU or GPU computation. GPU badges indicate specific vendor support (NVIDIA, AMD, Intel). <span style="color:green;">Green</span> = supported, <span style="color:darkred;">Red</span> = not supported.</dd>
+                    <dt>GDPR</dt>
+                    <dd>Some BOINC projects require you to opt in to exporting your statistics due to GDPR regulations. <strong>Solo crunchers must enable this to earn GRC</strong> — otherwise the network cannot see your contributions. Pool crunchers do not need to do this. Click "required" in the table for project-specific instructions, or see the <a href="/guides/gdpr-stats-export.htm">general GDPR stats export guide</a>.</dd>
+                    <dt>ZCD / WAS</dt>
+                    <dd><strong>ZCD</strong> (Zero Credit Days) — number of consecutive days a project has reported zero new credit. <strong>WAS</strong> (Whitelist Activity Score) — a rolling measure of project activity. A project is automatically greylisted when ZCD exceeds 7 and WAS drops below 0.1.<br>
+                    <em>Grace periods:</em> When autogreylisting first activates at the v13 block height, all projects receive a 7-superblock (~7 day) grace period while the ZCD/WAS metrics stabilize across the network. After that, newly whitelisted projects receive a 7-superblock (~7 day) grace period before greylisting rules apply. During grace periods, ZCD/WAS values are tracked but will not trigger greylisting.</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+
+    <h3 id="whitelist-process" class="anchor-adjust">Whitelist Process</h3>
+        <div class="container">
+        <p>Want a project whitelisted? Ask about it on the <code>#whitelisting-committee</code> channel on the Gridcoin Discord! More details about adding a project to the whitelist can be found on the <a href="/wiki/whitelist-process.html">whitelist process wiki page</a></p>
+        <p>The whitelist was created to increase security and to focus user's resources on active projects. See <a href="https://web.archive.org/web/20150416222027/cryptocointalk.com/topic/29841-discussion-boinc-whitelist-monitoring/">historical discussion</a></p>
+        </div>
 </section>
 <div class="container">
     <p>GeForce is a trademark, or registered trademark, of NVIDIA Corporation. // Radeon is a trademark, or registered trademark, of Advanced Micro Devices, Inc. // Intel is a trademark, or registered trademark, of Intel Corporation.</p>
 </div>
+
+<script src="/assets/js/fetch-whitelist.js"></script>

--- a/guides/whitelist.htm
+++ b/guides/whitelist.htm
@@ -93,6 +93,7 @@ redirect_from:
         </div>
         <div class="row text-center mb-5">
             <div class="col-12">
+                <div class="table-responsive">
                 <table class="table table-sm table-custom-dark table-hover table-striped table-bordered">
                     <thead>
                         <tr>
@@ -136,6 +137,7 @@ redirect_from:
                         {% endfor %}
                     </tbody>
                 </table>
+                </div>
             </div>
         </div>
     </div>
@@ -183,4 +185,5 @@ redirect_from:
     <p>GeForce is a trademark, or registered trademark, of NVIDIA Corporation. // Radeon is a trademark, or registered trademark, of Advanced Micro Devices, Inc. // Intel is a trademark, or registered trademark, of Intel Corporation.</p>
 </div>
 
+<script src="/assets/js/analytics-api.js"></script>
 <script src="/assets/js/fetch-whitelist.js"></script>


### PR DESCRIPTION
## Summary

Two related improvements that together drive a slice of `gridcoin.us`
off live wallet data rather than hand-curated YAML:

1. **`guides/whitelist.htm` → dynamic.** The projects table now fetches live superblock / project state from a small API proxy and merges it with the existing `_data/whitelist.yml` metadata (CPU/GPU support, descriptions, project-specific links). Falls back to the static table with a warning banner if the API is unreachable, so the page is never worse off than today.

2. **`guides/analytics.htm` (new).** A network-analytics page showing ~5.5 years of historical Gridcoin-network trends in four sections (CPID activity, project churn, per-project active-CPID counts, and a sortable top-researchers leaderboard).

Both pages share the same same-origin-or-reverse-proxied API URL scheme
and a common helper (`assets/js/analytics-api.js`). Chart.js v4 is
pulled from jsDelivr via CDN and only loaded on the analytics page.

## Live prototype

A local production-like deployment is running and is publicly reachable
while review is active:

- **Analytics:** http://jco-linux.jcowens.net:81/guides/analytics.htm
- **Whitelist (dynamic):** http://jco-linux.jcowens.net:81/guides/whitelist.htm

(Plain HTTP; the page shows public network data only, no secrets.)

## Architecture

```
Browser ──▶ gridcoin.us (GitHub Pages, static)
             │
             │ fetch /api/v1/*
             ▼
          api.gridcoin.us  (TLS-terminated by nginx/caddy on the scraper VPS)
             │
             ▼
          FastAPI proxy :5000  (see companion gridcoin-community/Gridcoin-Research PR)
             │
             ├──▶ local wallet RPC :15715
             ├──▶ ~/.GridcoinResearch/Scraper/ConvergedStats.csv.gz
             └──▶ ~/.GridcoinResearch/analytics/gridcoin_stats.duckdb
```

Client-side JS is split small, one file per section/chart, so any one
can be turned off without affecting the others. The API URL helper
(`analytics-api.js`) routes based on `window.location`:

- `gridcoin.us` / `www.gridcoin.us` → `https://api.gridcoin.us/...`
- Jekyll dev (`:4001`) → direct fetch to `:5000` on the same host
- anything else → relative `/api/v1/...`, assuming a same-origin reverse-proxy

## Navigation

Analytics is linked from the **Pool/Stats** header dropdown under a new
*Gridcoin Analytics* section (directly above *Gridcoin Pools*), and
from the site footer. The whitelist page already has its existing
entry under *Other Guides*.

## Dependencies

- [Chart.js v4](https://www.chartjs.org/) via jsDelivr CDN, analytics page only
- No build-step or npm dependency added; all JS is vanilla

## Test plan

- [x] Whitelist page renders the dynamic table against the API
- [x] Whitelist page falls back to the static table with the warning banner when the API is deliberately stopped
- [x] Analytics page renders all four sections
- [x] Table sort headers re-query the API with the chosen \`order_by\`
- [x] Project filter dropdown switches the leaderboard scope
- [x] Navigation link visible in Pool/Stats and footer
- [x] Verified on http://jco-linux.jcowens.net:81/

🤖 Generated with [Claude Code](https://claude.com/claude-code)