### PR TITLE
Whitelist: color and sort "Active by Greylist Override" as active

### DIFF
--- a/assets/js/fetch-whitelist.js
+++ b/assets/js/fetch-whitelist.js
@@ -67,6 +67,9 @@ function projectStatus(proj) {
     if (status === "Active") {
         return { text: "Active", cssClass: "status-active" };
     }
+    if (status === "Active by Greylist Override") {
+        return { text: "Active by Greylist Override", cssClass: "status-active" };
+    }
     return { text: status, cssClass: "" };
 }
 
@@ -179,11 +182,16 @@ function renderProjectTable(apiProjects, staticLookup) {
     // Sort projects: Active first, then Excluded (less severe — project
     // is whitelisted but its stats are stale), then Greylisted (most
     // severe — not earning rewards). Anything else falls to the bottom.
-    const sortOrder = { "Active": 0, "Excluded": 1, "Greylisted": 2 };
+    const sortOrder = {
+        "Active": 0,
+        "Active by Greylist Override": 1,
+        "Excluded": 2,
+        "Greylisted": 3,
+    };
     const entries = Object.entries(apiProjects).sort((a, b) => {
         const sa = projectStatus(a[1]).text;
         const sb = projectStatus(b[1]).text;
-        const orderDiff = (sortOrder[sa] || 9) - (sortOrder[sb] || 9);
+        const orderDiff = (sortOrder[sa] ?? 9) - (sortOrder[sb] ?? 9);
         if (orderDiff !== 0) return orderDiff;
         return a[0].localeCompare(b[0]);
     });
@@ -221,8 +229,8 @@ function renderProjectTable(apiProjects, staticLookup) {
         // Status badge.
         const statusCell = document.createElement("td");
         const badge = document.createElement("span");
-        const badgeColor = status.text === "Active" ? "success"
-                         : status.text === "Excluded" ? "warning"
+        const badgeColor = status.cssClass === "status-active" ? "success"
+                         : status.cssClass === "status-excluded" ? "warning"
                          : "danger";
         badge.className = `badge bg-${badgeColor}`;
         badge.textContent = status.text;


### PR DESCRIPTION
## Summary

- Status badge for `Active by Greylist Override` was rendering red — it fell through `projectStatus()`'s default branch (empty `cssClass`) and the badge-color check routed anything not literally `Active` or `Excluded` to `danger`. Override projects are in the superblock and earning rewards, so they should read as active, not greylisted.
- `projectStatus()` now returns `cssClass: "status-active"` for the override status (keeping the distinct display label so the override is still visible under the project name). The badge-color check now keys off `cssClass` rather than the raw display text, so the semantic category drives the color.
- `sortOrder` gains an entry between `Active` and `Excluded` so override rows sort with the active group, ahead of greylisted rows.
- Drive-by: `sortOrder[x] || 9` collapsed `0` (Active's ordinal) to `9` via JS falsiness — `??` instead. Not visible today because every active project on the live whitelist is currently flagged as override, but would surface as soon as any plain-Active project appeared.

## Test plan

- [x] Local preview at `http://jco-linux.jcowens.net:81/whitelist.htm`: override rows render with a green `bg-success` badge and sort within the active group, ahead of greylisted rows.
- [x] Greylisted and excluded rows unchanged (red and yellow badges respectively).
- [ ] Spot-check after merge that the live site renders override rows green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)