### PR TITLE
Whitelist: replace "in superblock" count with project-by-project "active" count

### DIFF
--- a/assets/js/fetch-whitelist.js
+++ b/assets/js/fetch-whitelist.js
@@ -120,7 +120,7 @@ function summaryCell(label, value) {
 /**
  * Render the superblock summary header.
  */
-function renderSuperblockHeader(sb, totalWhitelisted) {
+function renderSuperblockHeader(sb, totalWhitelisted, activeCount) {
     const el = document.getElementById("superblock-info");
     if (!el || !sb) return;
 
@@ -128,9 +128,17 @@ function renderSuperblockHeader(sb, totalWhitelisted) {
 
     const row = document.createElement("div");
     row.className = "row text-center mb-3";
+    // "Active" counts projects rendered with the status-active class — i.e.
+    // status "Active" with in_superblock=true, plus "Active by Greylist
+    // Override" (which is always in-superblock by API definition). This is
+    // not derivable from sb.total_projects because manually-greylisted
+    // projects can still appear in the superblock contract with Mag=0, and
+    // the unreachable-and-greylisted case (excluded by scrapers AND
+    // greylisted) makes "in_superblock − greylisted − excluded" wrong; the
+    // overlap forces a project-by-project pass.
     row.appendChild(summaryCell(
         "Whitelisted Projects",
-        `${totalWhitelisted} (${sb.total_projects} in superblock)`,
+        `${totalWhitelisted} (${activeCount} active)`,
     ));
     row.appendChild(summaryCell("Active Beacons", formatNumber(sb.active_beacons)));
     row.appendChild(summaryCell("Total CPIDs",   formatNumber(sb.total_cpids)));
@@ -334,7 +342,9 @@ function initWhitelist() {
             if (!data || !data.projects) throw new Error("Invalid API response");
 
             const totalWhitelisted = Object.keys(data.projects).length;
-            renderSuperblockHeader(data.superblock, totalWhitelisted);
+            const activeCount = Object.values(data.projects)
+                .filter(p => projectStatus(p).cssClass === "status-active").length;
+            renderSuperblockHeader(data.superblock, totalWhitelisted, activeCount);
             renderProjectTable(data.projects, staticLookup);
 
             // Show dynamic table, hide static fallback.


### PR DESCRIPTION
## Summary

- The summary header reads `Whitelisted Projects: N (M in superblock)`, where `M` is `sb.total_projects` straight from the superblock contract. That count includes manually-greylisted projects whose scraper-converged stats still landed in the superblock with `Mag=0`, so the headline overstates how many projects are actually earning rewards. On the live data today the cell reads **`16 (15 in superblock)`** while only **11** projects are accruing.
- Replace the parenthetical with a project-by-project active count → **`16 (11 active)`**.
- The new count filters on `projectStatus(p).cssClass === "status-active"`, which already maps both `"Active"` (with `in_superblock=true`) and `"Active by Greylist Override"` to `status-active`, and routes `"Active" + in_superblock=false` to `status-excluded`. So one filter pass picks up exactly the active-and-in-superblock projects.

### Why it can't just be `in_superblock − greylisted − excluded`

The greylisted set and the excluded-by-scrapers set overlap. A manually-greylisted project whose stats host is also unreachable (e.g. SiDock@home on mainnet today — site hard-down, picked up by `convergencereport`'s `excluded_projects`) is both greylisted *and* excluded by scrapers. Set arithmetic on the aggregate counts double-counts that project; the only correct computation is project-by-project.

## Test plan

- [x] Local preview at `http://jco-linux.jcowens.net:81/whitelist.htm` shows `Whitelisted Projects 16 (11 active)` on current mainnet data (11 `Active by Greylist Override`, 4 manually-greylisted-but-in-superblock, 1 manually-greylisted-and-unreachable).
- [x] Greylisted-row badges still red, excluded-row badges still yellow, active-row badges still green (no regression from #451).
- [ ] Spot-check after merge that the live site headline matches the table contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)